### PR TITLE
add setup instructions in a top-level README.md file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,51 @@
+# Building the XMUtil XMILE utilities
+
+Windows is required to build and run XMUtil. These instructions were developed on Windows 10.
+
+Microsoft Visual Studio is required for the C++ compiler. These instructions use Visual Studio Community 2015.
+
+Use the "VS2015 x86 Native Tools Command Prompt" for all commands. `XMUtil` is built as 32-bit software.
+
+## Install dependencies
+
+### Boost C++ Libraries
+
+Download and extract the latest version of [Boost](http://www.boost.org/users/download/).
+
+Follow the instructions in [Boost Getting Started on Windows](http://www.boost.org/doc/libs/1_63_0/more/getting_started/windows.html).
+~~~
+cd boost
+bootstrap
+.\b2
+~~~
+
+Note the include and library paths emitted at the end of the build process.
+
+### ICU - International Components for Unicode
+
+Download [ICU4C](http://site.icu-project.org/download/57#TOC-ICU4C-Download)version 57.1 binaries for Win32. This is the last version with 32-bit binaries.
+
+### Win flex-bison - Flex (the fast lexical analyser) and Bison (GNU parser generator)
+
+Download and extract [Win flex-bison](http://sourceforge.net/projects/winflexbison/).
+
+### TinyXML - XML Parser
+
+Download and extract [TinyXML-2](https://github.com/leethomason/tinyxml2).
+
+## Build XMUtil
+
+Set dependency directories in the `setup.bat` file in the `third_party` directory. You may also need to change the Boost library path according to the output of the Boost build process.
+
+Open the "VS2015 x86 Native Tools Command Prompt" as administrator and run `setup.bat`.
+
+Open the `XMUtil.vcxproj` project in Visual Studio. The project settings will be upgraded if necessary.
+
+Choose Build Solution from the Build menu. Bison will generate code. The build result is `XMUtil.exe` in the Debug directory.
+
+## Convert a Vensim model to XMILE
+
+Switch to the directory where your `.mdl` file is located. Run XMUtil on the `.mdl` file to generate an `.xmile` file in the same directory. Press any key after the converter runs to end the process.
+~~~
+{/path/to/xmutil/debug}/XMUtil.exe {mdl-file}
+~~~

--- a/third_party/setup.bat
+++ b/third_party/setup.bat
@@ -1,12 +1,11 @@
 REM @echo off
-REM http://sourceforge.net/projects/winflexbison/
-REM http://site.icu-project.org/download
+REM See the README.md file for setup instructions before running this setup script.
 
 REM - must be run as administrator
 
 SET "ICU_PATH=D:\tools\icu"
 SET "BOOST_PATH=D:\tools\boost"
-SET "BISON_PATH=D:\tools\bison\bin"
+SET "BISON_PATH=D:\tools\bison"
 SET "TINY_XML_PATH=D:\tools\tinyxml2"
 
  IF NOT EXIST ".\include" GOTO NOINCLUDE
@@ -45,7 +44,7 @@ FOR %%G IN ("%BOOST_PATH%\boost\*") DO (
     mklink  ".\include\boost\%%~nxG" "%%G"
 )
 
-FOR %%G IN ("%BOOST_PATH%\lib32-msvc-12.0\*") DO (
+FOR %%G IN ("%BOOST_PATH%\stage\lib\*") DO (
     mklink  ".\lib32\%%~nxG" "%%G"
 )
 
@@ -63,4 +62,3 @@ FOR %%G IN ("%TINY_XML_PATH%\lib32\*") DO (
 )
 
 mklink /D ".\bison" "%BISON_PATH%"
-


### PR DESCRIPTION
I also changed the setup script to reference the README and use some updated paths I found in Visual Studio 2015 and the third-party dependencies. This could be parameterized if you still want to support older versions.