### PR TITLE
Xmile/XMILEGenerator: emit isee:save_interval as an attribute, not child

### DIFF
--- a/src/Xmile/XMILEGenerator.cpp
+++ b/src/Xmile/XMILEGenerator.cpp
@@ -178,9 +178,7 @@ void XMILEGenerator::generateSimSpecs(tinyxml2::XMLElement* element, std::vector
 
 	if (saveper > dt)
 	{
-		tinyxml2::XMLElement* spE = doc->NewElement("isee:save_interval");
-		spE->SetText(StringFromDouble(saveper).c_str());
-		element->InsertEndChild(spE);
+		element->SetAttribute("isee:save_interval", std::to_string(saveper).c_str());
 	}
 
 	_model->SetUnwanted("INITIAL TIME", "STARTTIME");


### PR DESCRIPTION
Stella writes out save_interval as an attribute on the sim_specs tag.  Do the same here to be consistent.  (The library I'm using for XML serialization/deserialization doesn't make it easy to say "read this as an attribute, but if thats missing check for a child tag")

cc @bobeberlein @wasbridge  