### PR TITLE
remove Boost dependencies that are now standard in C++11 and 14

### DIFF
--- a/build/common.gypi
+++ b/build/common.gypi
@@ -115,7 +115,7 @@
                 'xcode_settings': {
                     'MACOSX_DEPLOYMENT_TARGET':'10.7',
                     'CLANG_CXX_LIBRARY': 'libc++',
-                    'CLANG_CXX_LANGUAGE_STANDARD': 'gnu++11',
+                    'CLANG_CXX_LANGUAGE_STANDARD': 'gnu++14',
                     'SDKROOT': 'macosx',
                     'GCC_OPTIMIZATION_LEVEL': '0',
                     'OTHER_CFLAGS': [
@@ -206,7 +206,7 @@
                     '-Wno-unused-function',
                     '-Wno-unknown-pragmas',
                     '-Wno-parentheses',
-                    '-std=c++11',
+                    '-std=c++14',
                     '-fPIC',
                 ],
                 'libraries': [

--- a/src/Function/Function.h
+++ b/src/Function/Function.h
@@ -1,7 +1,6 @@
 #ifndef _XMUTIL_SYMBOL_FUNCTION_H
 #define _XMUTIL_SYMBOL_FUNCTION_H
 #include "../Symbol/Symbol.h"
-#include <boost/utility.hpp>
 #include "State.h"
 
 class Expression ; /* forward declaration */
@@ -202,8 +201,8 @@ public:
 };
 
 
-FSubclassMemory(FunctionInteg, "INTEG", 2, BOOST_BINARY(10), BOOST_BINARY(01), "integ_active", "integ_init")
-FSubclassMemoryStart(FunctionActiveInitial, "ACTIVE INITIAL", 2, BOOST_BINARY(10), BOOST_BINARY(01), "ai_active", "ai_init")
+FSubclassMemory(FunctionInteg, "INTEG", 2, 0b10, 0b01, "integ_active", "integ_init")
+FSubclassMemoryStart(FunctionActiveInitial, "ACTIVE INITIAL", 2, 0b10, 0b01, "ai_active", "ai_init")
 virtual bool IsActiveInit() override { return true; }
 };
 FSubclass(FunctionInitial, "INITIAL", 1, "INIT")

--- a/src/Model.cpp
+++ b/src/Model.cpp
@@ -2,8 +2,6 @@
 #include "Symbol/Symbol.h"
 #include "Symbol/LeftHandSide.h"
 #include "Symbol/Equation.h"
-#include <boost/foreach.hpp>
-#include <boost/lexical_cast.hpp>
 #include <vector>
 #include "XMUtil.h"
 #include "Xmile/XMILEGenerator.h"
@@ -46,11 +44,11 @@ void Model::ClearCompEquations(void)
    vInitialTimeComps.clear() ;
 
    SymbolNameSpace::HashTable *ht = mSymbolNameSpace.GetHashTable() ;
-   BOOST_FOREACH(const SymbolNameSpace::iterator it,*ht) {
+   for (const SymbolNameSpace::iterator &it: *ht) {
       SNSitToSymbol(it)->SetupState(NULL) ;
       SNSitToSymbol(it)->CheckPlaceholderVars(NULL) ;
    }
-   BOOST_FOREACH(Variable *v,vUnamedVars) {
+   for (Variable *v: vUnamedVars) {
       v->GetEquation(0)->GetExpression()->RemoveFunctionArgs() ; // these are allocated in the real variable's equation
       v->SetupState(NULL) ;
       delete v ;
@@ -80,7 +78,7 @@ bool Model::OrganizeSubscripts(void)
    SubInfoWCount siwc ;
    try {
       SymbolNameSpace::HashTable *ht = mSymbolNameSpace.GetHashTable() ;
-      BOOST_FOREACH(const SymbolNameSpace::iterator it,*ht) {
+      for (const SymbolNameSpace::iterator &it: *ht) {
          siwc.v = static_cast<Variable *>SNSitToSymbol(it) ;
          if(siwc.count = siwc.v->SubscriptCount(subelm)) {
             sublist.push_back(siwc) ;
@@ -99,7 +97,7 @@ bool Model::ValidatePlaceholderVars(void)
 {
    try {
       SymbolNameSpace::HashTable *ht = mSymbolNameSpace.GetHashTable() ;
-      BOOST_FOREACH(const SymbolNameSpace::iterator it,*ht) {
+      for (const SymbolNameSpace::iterator &it: *ht) {
          //printf("Checking placeholders out %s\n",SNSitToSymbol(it)->GetName().c_str()) ;
          SNSitToSymbol(it)->CheckPlaceholderVars(this) ;
       }
@@ -139,11 +137,11 @@ bool Model::SetupVariableStates(int pass/* 0 just assign, 1 determine sizes, 2 p
          info.pBaseLevel = info.pCurLevel = NULL ;
          info.iComputeType = 0 ;
       }
-      BOOST_FOREACH(const SymbolNameSpace::iterator it,*ht) {
+      for (const SymbolNameSpace::iterator &it: *ht) {
          SNSitToSymbol(it)->SetupState(&info) ;
       }
       // placeholder vars also need state set up 
-      BOOST_FOREACH(Variable *v,vUnamedVars) {
+      for (Variable *v: vUnamedVars) {
          v->SetupState(&info) ;
       }
       mSymbolNameSpace.ConfirmAllAllocations() ;
@@ -153,7 +151,7 @@ bool Model::SetupVariableStates(int pass/* 0 just assign, 1 determine sizes, 2 p
       }
    }  catch(...) {
       // set all states to null - they will be deleted
-      BOOST_FOREACH(const SymbolNameSpace::iterator it,*ht) {
+      for (const SymbolNameSpace::iterator &it: *ht) {
          SNSitToSymbol(it)->SetupState(NULL) ; // clear if setup 
       }
       mSymbolNameSpace.DeleteAllUnconfirmedAllocations() ;
@@ -195,12 +193,12 @@ bool Model::OrderEquations(ContextInfo *info,bool tonly)
          if(!v || !v->CheckComputed(info,false))
             haserr = true ;
       } else {
-         BOOST_FOREACH(const SymbolNameSpace::iterator it,*ht) {
+         for (const SymbolNameSpace::iterator &it: *ht) {
             //printf("Looping to: %s\n",SNSitToSymbol(it)->GetName().c_str()) ;
             if(!SNSitToSymbol(it)->CheckComputed(info,true))
                haserr = true ; // continue looking for simultaneous even when false 
          }
-         BOOST_FOREACH(Variable *v,vUnamedVars) {
+         for (Variable *v: vUnamedVars) {
             if(!v->CheckComputed(info,true))
                haserr = true ;
          }
@@ -290,7 +288,7 @@ bool Model::Simulate(void)
       n = iNLevel ;
 
       info.iComputeType = CF_initial ;
-      BOOST_FOREACH(Equation *e,vInitialTimeComps) {
+      for (Equation *e: vInitialTimeComps) {
          e->Execute(&info) ;
          //printf("%s = %g\n",e->GetVariable()->GetName().c_str(),e->GetVariable()->Eval(&info)) ;
       }
@@ -304,7 +302,7 @@ bool Model::Simulate(void)
          dt = 1 ;
       info.dTime = s ;
       info.dDT = dt ;
-      BOOST_FOREACH(Equation *e,vInitialComps) {
+      for (Equation *e: vInitialComps) {
          e->Execute(&info) ;
          //printf("%s = %g\n",e->GetVariable()->GetName().c_str(),e->GetVariable()->Eval(&info)) ;
       }
@@ -312,7 +310,7 @@ bool Model::Simulate(void)
       info.iComputeType = CF_active ;
       // first the unchanging variables
       //printf("\n Unchanging\n") ;
-      BOOST_FOREACH(Equation *e,vUnchangingComps) {
+      for (Equation *e: vUnchangingComps) {
          e->Execute(&info) ;
          //printf("%s = %g\n",e->GetVariable()->GetName().c_str(),e->GetVariable()->Eval(&info)) ;
       }
@@ -323,10 +321,10 @@ bool Model::Simulate(void)
       else
          e = 100 ;
       printf("Time") ;
-      BOOST_FOREACH(Equation *e,vActiveComps) {
+      for (Equation *e: vActiveComps) {
          printf("\t%s",e->GetVariable()->GetName().c_str()) ;
       } ;
-      BOOST_FOREACH(Equation *e,vRateComps) {
+      for (Equation *e: vRateComps) {
          printf("\t%s",e->GetVariable()->GetName().c_str()) ;
       } printf("\n") ;
 
@@ -336,11 +334,11 @@ bool Model::Simulate(void)
          if(time)
             time->SetActiveValue(0,t) ;
          printf("%g",t) ;
-         BOOST_FOREACH(Equation *e,vActiveComps) {
+         for (Equation *e: vActiveComps) {
             e->Execute(&info) ;
             printf("\t%g",e->GetVariable()->Eval(&info)) ;
          } 
-         BOOST_FOREACH(Equation *e,vRateComps) {
+         for (Equation *e: vRateComps) {
             e->Execute(&info) ;
             printf("\t%g",e->GetVariable()->Eval(&info)) ;
          } printf("\n") ;
@@ -370,26 +368,26 @@ bool Model::OutputComputable(bool wantshort)
          GenerateCanonicalNames() ;
       info.iComputeType = CF_initial ;
       printf("------------- initial time -----------------\n") ;
-      BOOST_FOREACH(Equation *e,vInitialTimeComps) {
+      for (Equation *e: vInitialTimeComps) {
          e->OutputComputable(&info) ;
       }
       printf("------------- initialization -----------------\n") ;
-      BOOST_FOREACH(Equation *e,vInitialComps) {
+      for (Equation *e: vInitialComps) {
          e->OutputComputable(&info) ;
       }
       info.iComputeType = CF_active ;
       printf("------------- Unchanging -----------------\n") ;
       info.iComputeType = CF_active ;
-      BOOST_FOREACH(Equation *e,vUnchangingComps) {
+      for (Equation *e: vUnchangingComps) {
          e->OutputComputable(&info) ;
       }
       printf("------------- active -----------------\n") ;
-      BOOST_FOREACH(Equation *e,vActiveComps) {
+      for (Equation *e: vActiveComps) {
          e->OutputComputable(&info) ;
       } 
       info.iComputeType = CF_rate ;
       printf("------------- rates -----------------\n") ;
-      BOOST_FOREACH(Equation *e,vRateComps) {
+      for (Equation *e: vRateComps) {
          e->OutputComputable(&info) ;
       } 
    } catch(...) {
@@ -411,14 +409,14 @@ bool Model::MarkVariableTypes(SymbolNameSpace* ns)
 			ns = &mSymbolNameSpace;
 		}
 		std::vector<Variable*> vars;
-		BOOST_FOREACH(const SymbolNameSpace::iterator it, *ht) {
+		for (const SymbolNameSpace::iterator &it: *ht) {
 			Symbol* sym = SNSitToSymbol(it);
 
 			if (sym->isType() == Symtype_Variable)
 				vars.push_back(static_cast<Variable*>(sym));
 		}
 		// 
-		BOOST_FOREACH(Variable* var, vars)
+		for (Variable* var: vars)
 		{
             var->PurgeAFOEq();
 			var->MarkFlows(ns); // may change number of entries so can't be in above loop
@@ -435,7 +433,7 @@ bool Model::MarkVariableTypes(SymbolNameSpace* ns)
 	ContextInfo info;
 
 	SymbolNameSpace::HashTable *ht = mSymbolNameSpace.GetHashTable();
-	BOOST_FOREACH(const SymbolNameSpace::iterator it, *ht) {
+	for (const SymbolNameSpace::iterator &it: *ht) {
 		Symbol* sym = SNSitToSymbol(it);
 
 		if (sym->isType() == Symtype_Variable)
@@ -443,7 +441,7 @@ bool Model::MarkVariableTypes(SymbolNameSpace* ns)
 			Variable*var = static_cast<Variable*>(sym);
 			VariableContent* content = var->Content();
 			if (content) { // array elements don't have
-				BOOST_FOREACH(Equation* eq, content->GetAllEquations())
+				for (Equation* eq: content->GetAllEquations())
 				{
 					eq->OutputComputable(&info);
 				}
@@ -459,7 +457,7 @@ void Model::AttachStragglers()
 {
 	SymbolNameSpace::HashTable *ht = mSymbolNameSpace.GetHashTable();
 	std::vector<Variable*> vars;
-	BOOST_FOREACH(const SymbolNameSpace::iterator it, *ht) {
+	for (const SymbolNameSpace::iterator &it: *ht) {
 		Symbol* sym = SNSitToSymbol(it);
 
 		if (sym->isType() == Symtype_Variable)
@@ -467,11 +465,11 @@ void Model::AttachStragglers()
 	}
 	// first try - anything that is not defined somewhere see if a ghost appears somewhere
 	// and change that to the definition
-	BOOST_FOREACH(Variable* var, vars)
+	for (Variable* var: vars)
 	{
 		if (!var->GetView())
 		{
-			BOOST_FOREACH(View* view, vViews)
+			for (View* view: vViews)
 			{
 				if (view->UpgradeGhost(var))
 					break;
@@ -479,18 +477,18 @@ void Model::AttachStragglers()
 		}
 	}
 	// now try undefined flows - attach to associated stocks
-	BOOST_FOREACH(Variable* var, vars)
+	for (Variable* var: vars)
 	{
 		if (!var->GetView() && var->VariableType() == XMILE_Type_FLOW)
 		{
 			// we don't know flows uses so just look at all stocks
 			Variable* upstream = NULL;
 			Variable* downstream = NULL;
-			BOOST_FOREACH(Variable* stock, vars)
+			for (Variable* stock: vars)
 			{
 				if (stock->VariableType() == XMILE_Type_STOCK)
 				{
-					BOOST_FOREACH(Variable* in, stock->Inflows())
+					for (Variable* in: stock->Inflows())
 					{
 						if (in == var)
 						{
@@ -498,7 +496,7 @@ void Model::AttachStragglers()
 							break;
 						}
 					}
-					BOOST_FOREACH(Variable* out, stock->Outflows())
+					for (Variable* out: stock->Outflows())
 					{
 						if (out == var)
 						{
@@ -526,7 +524,7 @@ void Model::AttachStragglers()
 	if (!vViews.empty())
 	{
 		View* dump_view = vViews[0];
-		BOOST_FOREACH(Variable* var, vars)
+		for (Variable* var: vars)
 		{
 			if (!var->GetView() && var->VariableType() != XMILE_Type_ARRAY && var->VariableType() != XMILE_Type_ARRAY_ELM && var->VariableType() != XMILE_Type_UNKNOWN)
 				dump_view->AddVarDefinition(var, 200, 200);
@@ -534,7 +532,7 @@ void Model::AttachStragglers()
 	}
 
 	// now everything is defined (and only defined once) - we need to make sure there are no missing connectors
-	BOOST_FOREACH(View* view, vViews)
+	for (View* view: vViews)
 	{
 		view->CheckLinksIn();
 	}
@@ -564,21 +562,19 @@ void Model::GenerateCanonicalNames(void)
 
 void Model::GenerateShortNames(void)
 {
-   Variable *v ;
    int i = 0 ;
-   std::string s ;
    SymbolNameSpace::HashTable *ht = mSymbolNameSpace.GetHashTable() ;
-   BOOST_FOREACH(const SymbolNameSpace::iterator it,*ht) {
-      v = static_cast<Variable *>SNSitToSymbol(it) ;
+   for (const SymbolNameSpace::iterator &it: *ht) {
+      Variable *v = static_cast<Variable *>SNSitToSymbol(it) ;
       if(v->isType() == Symtype_Variable) {
-         s = "v" + boost::lexical_cast<std::string>(i); ;
+         std::string s = "v" + std::to_string(i);
          i++;
          v->SetAlternateName(s) ;
          //v->SetAlternateName(v->GetName()) ;
       }
    }
-   BOOST_FOREACH(v,vUnamedVars) {
-      s = "v" + boost::lexical_cast<std::string>(i); ;
+   for (Variable *v: vUnamedVars) {
+      std::string s = "v" + std::to_string(i);
       i++;
       v->SetAlternateName(s) ;
    }

--- a/src/Symbol/Expression.cpp
+++ b/src/Symbol/Expression.cpp
@@ -122,7 +122,7 @@ static void is_all_plus_minus(Expression *e, FlowList* fl,bool neg)
 }
 void ExpressionVariable::GetVarsUsed(std::vector<Variable*>& vars)
 { 
-	BOOST_FOREACH(Variable* var, vars)
+	for (Variable* var: vars)
 	{
 		if (var == pVariable)
 			return;

--- a/src/Symbol/ExpressionList.cpp
+++ b/src/Symbol/ExpressionList.cpp
@@ -1,5 +1,4 @@
 #include "ExpressionList.h"
-#include <boost/foreach.hpp>
 #include "../XMUtil.h"
 
 
@@ -13,7 +12,7 @@ ExpressionList::ExpressionList(SymbolNameSpace *sns)
 ExpressionList::~ExpressionList(void)
 {
    if(this->HasGoodAlloc()) {
-      BOOST_FOREACH(Expression *e,vExpressions) {
+      for (Expression *e: vExpressions) {
          delete e ;
       }
    }
@@ -21,7 +20,7 @@ ExpressionList::~ExpressionList(void)
 
 void ExpressionList::CheckPlaceholderVars(Model *m) 
 {
-   BOOST_FOREACH(Expression *e,vExpressions) {
+   for (Expression *e: vExpressions) {
       e->CheckPlaceholderVars(m,false) ;
    }
 }
@@ -29,7 +28,7 @@ void ExpressionList::CheckPlaceholderVars(Model *m)
 bool ExpressionList::CheckComputed(ContextInfo *info,unsigned wantargs) 
 {
    int i = 1 ;
-   BOOST_FOREACH(Expression *e,vExpressions) {
+   for (Expression *e: vExpressions) {
       if(i&wantargs) {
          if(!e->CheckComputed(info))
             return false ;
@@ -43,7 +42,7 @@ void ExpressionList::OutputComputable(ContextInfo *info,unsigned wantargs)
 {
    int i = 1 ;
    int j = 0 ;
-   BOOST_FOREACH(Expression *e,vExpressions) {
+   for (Expression *e: vExpressions) {
       if(i&wantargs) {
          if(j++)
             *info << ", " ;

--- a/src/Symbol/SymbolList.cpp
+++ b/src/Symbol/SymbolList.cpp
@@ -53,7 +53,7 @@ void SymbolList::SetOwner(Variable* var)
 			vSymbols[i].u.pSymbol->SetOwner(var);
 		}
 	}
-	BOOST_FOREACH(Symbol* s, expanded)
+	for (Symbol* s: expanded)
 	{
 		s->SetOwner(var);
 	}

--- a/src/Symbol/SymbolNameSpace.cpp
+++ b/src/Symbol/SymbolNameSpace.cpp
@@ -1,8 +1,10 @@
+#include <assert.h>
+#include <string.h>
+
+#include "unicode/ucasemap.h"
+
 #include "SymbolNameSpace.h"
 #include "Symbol.h"
-#include <assert.h>
-#include "unicode/ucasemap.h"
-#include <boost/foreach.hpp>
 #include "../XMUtil.h"
 
 
@@ -16,7 +18,7 @@ SymbolNameSpace::SymbolNameSpace(void)
 SymbolNameSpace::~SymbolNameSpace(void)
 {
    /* delete the symbols which will in turn delete equations etc */
-  // BOOST_FOREACH(iterator node,mHashTable) {
+  // for (iterator node: mHashTable) {
   //    delete SNSitToSymbol(node) ;
   // }
 
@@ -151,7 +153,7 @@ void SymbolNameSpace::DeleteAllUnconfirmedAllocations(void)
 
 void SymbolNameSpace::ConfirmAllAllocations(void) 
 {
-   BOOST_FOREACH(std::set<SymbolTableBase*>::value_type i,sUnconfirmedAllocations) {
+   for (std::set<SymbolTableBase*>::value_type i: sUnconfirmedAllocations) {
       i->MarkGoodAlloc() ;
    }
    sUnconfirmedAllocations.clear() ;

--- a/src/Symbol/SymbolNameSpace.h
+++ b/src/Symbol/SymbolNameSpace.h
@@ -2,7 +2,6 @@
 #define _XMUTIL_SYMBOL_NAMESPACE_H
 #include <string>
 #include <unordered_map>
-#include <boost/foreach.hpp>
 #include <set>
 class Symbol ;
 class SymbolTableBase ; // forward declaration 
@@ -30,7 +29,7 @@ public:
    void RemoveUnconfirmedAllocation(SymbolTableBase *s) { sUnconfirmedAllocations.erase(s) ; }
    inline void AddUnconfirmedAllocation(SymbolTableBase *s) { sUnconfirmedAllocations.insert(s) ; }
    typedef std::unordered_map<std::string, Symbol*> HashTable ;
-   typedef HashTable::value_type iterator ; // allows iterator type to be used directly with BOOST_FOREACH
+   typedef HashTable::value_type iterator ; // allows iterator type to be used directly with C++11 range-based for loops
    inline HashTable *GetHashTable(void) { return &mHashTable ; } 
 
 private :

--- a/src/Symbol/Variable.cpp
+++ b/src/Symbol/Variable.cpp
@@ -1,11 +1,12 @@
-#include "Variable.h"
-#include <boost/foreach.hpp>
 #include <assert.h>
+#include <iostream>
+
+#include "boost/lexical_cast.hpp"
+
+#include "Variable.h"
 #include "../Symbol/Expression.h"
 #include "../Symbol/LeftHandSide.h"
 #include "../XMUtil.h"
-#include "boost/lexical_cast.hpp"
-#include <iostream>
 
 // model Variable - this has subscript (families) units
 // and the comment attached to it - inside of expressions
@@ -156,7 +157,7 @@ XMILE_Type Variable::MarkFlows(SymbolNameSpace* sns)
 				exp->GetVarsUsed(vars);
 				// the first should be a graphical
 				std::vector<Equation*> eqs = vars[0]->GetAllEquations();
-				BOOST_FOREACH(Equation* eq, eqs)
+				for (Equation* eq: eqs)
 				{
 					Expression* exp = eq->GetExpression();
 					if (exp->GetType() == EXPTYPE_Table)
@@ -191,7 +192,7 @@ XMILE_Type Variable::MarkFlows(SymbolNameSpace* sns)
 	flow_lists.resize(equations.size());
 	size_t i = 0;
 	bool match = true;
-	BOOST_FOREACH(Equation* eq, equations)
+	for (Equation* eq: equations)
 	{
 		Expression* exp = eq->GetExpression();
 		if (!exp->TestMarkFlows(sns, &flow_lists[i], NULL) || !flow_lists[i].Valid())
@@ -202,12 +203,12 @@ XMILE_Type Variable::MarkFlows(SymbolNameSpace* sns)
 	}
 	if (match)
 	{
-		BOOST_FOREACH(Variable* v, flow_lists[0].Inflows())
+		for (Variable* v: flow_lists[0].Inflows())
 		{
 			v->SetVariableType(XMILE_Type_FLOW);
 			mInflows.push_back(v);
 		}
-		BOOST_FOREACH(Variable* v, flow_lists[0].Outflows())
+		for (Variable* v: flow_lists[0].Outflows())
 		{
 			v->SetVariableType(XMILE_Type_FLOW);
 			mOutflows.push_back(v);
@@ -231,7 +232,7 @@ XMILE_Type Variable::MarkFlows(SymbolNameSpace* sns)
 	// now we swap the active part of the INTEG equation for v and set v's equation to
 	// the active part - this is equation by equation 
 	i = 0;
-	BOOST_FOREACH(Equation* eq, equations)
+	for (Equation* eq: equations)
 	{
 		// left hand side for this variable
 		LeftHandSide *lhs = new LeftHandSide(sns, *eq->GetLeft(),v); // replace var in lhs equation
@@ -272,7 +273,7 @@ void VariableContentVar::Clear(void)
 std::vector<Variable*> VariableContentVar::GetInputVars()
 {
 	std::vector<Variable*> vars;
-	BOOST_FOREACH(Equation* eq, this->vEquations)
+	for (Equation* eq: this->vEquations)
 		eq->GetVarsUsed(vars);
 	return vars;
 }
@@ -314,7 +315,7 @@ VariableContent::~VariableContent(void)
 
 void VariableContentVar::CheckPlaceholderVars(Model *m)
 {
-   BOOST_FOREACH(Equation *eq,vEquations) {
+   for (Equation *eq: vEquations) {
       eq->CheckPlaceholderVars(m) ;
    }
 }
@@ -365,7 +366,7 @@ bool VariableContentVar::CheckComputed(Symbol *parent,ContextInfo *info,bool fir
             info->AddDDF(DDF_time_varying) ;
       }
       pState->cComputeFlag |= intype ;
-      BOOST_FOREACH(Equation*e,vEquations) {
+      for (Equation* e: vEquations) {
          if(!e->GetExpression()->CheckComputed(info)) {
             std::cout << "     " << parent->GetName() << std::endl ;
             pState->cComputeFlag &= ~intype ;
@@ -395,7 +396,7 @@ bool VariableContentVar::CheckComputed(Symbol *parent,ContextInfo *info,bool fir
          return true ;
    }
    printf("Outputting equations for  %s\n",parent->GetName().c_str()) ;
-   BOOST_FOREACH(Equation*e,vEquations) {
+   for (Equation* e: vEquations) {
       info->PushEquation(e) ;
    }
    return true ;
@@ -416,7 +417,7 @@ void  VariableContentVar::SetupState(ContextInfo *info)
          return ; // do nothing no state allocated on the previous try
       // find out what defines this to determine type
       bool haseq = false ;
-      BOOST_FOREACH(Equation*e,vEquations) {
+      for (Equation* e: vEquations) {
          haseq = true ;
          if(e->GetExpression()->GetType() == EXPTYPE_Table) {
             return ; // for now no state assigned 

--- a/src/Symbol/Variable.cpp
+++ b/src/Symbol/Variable.cpp
@@ -1,8 +1,6 @@
 #include <assert.h>
 #include <iostream>
 
-#include "boost/lexical_cast.hpp"
-
 #include "Variable.h"
 #include "../Symbol/Expression.h"
 #include "../Symbol/LeftHandSide.h"
@@ -223,7 +221,7 @@ XMILE_Type Variable::MarkFlows(SymbolNameSpace* sns)
 	while (sns->Find(name))
 	{
 		++i;
-		name = basename + "_" + boost::lexical_cast<std::string>(i);
+		name = basename + "_" + std::to_string(i);
 	}
 	Variable* v = new Variable(sns, name);
 	v->SetVariableType(XMILE_Type_FLOW);

--- a/src/UI/Main_Window.cpp
+++ b/src/UI/Main_Window.cpp
@@ -59,7 +59,7 @@ void Main_Window::choose_file()
         std::vector<std::string> errs;
         m.WriteToXMILE(p.string(), errs);
         
-        BOOST_FOREACH(const std::string& err, errs)
+        for (const std::string& err: errs)
         {
             ui->log->append(StdString_to_QString(err));
         }

--- a/src/Vensim/VensimParse.cpp
+++ b/src/Vensim/VensimParse.cpp
@@ -7,7 +7,6 @@
 #include "../Symbol/Variable.h"
 #include "../Symbol/LeftHandSide.h"
 #include "../Symbol/ExpressionList.h"
-#include <boost/lexical_cast.hpp>
 #define YYSTYPE VensimParse
 #include "VYacc.tab.hpp"
 #include "../XMUtil.h"
@@ -367,7 +366,7 @@ bool VensimParse::ProcessFile(const std::string &filename)
 	   {
 		   // try to replace variable names with long names from the documentaion
 		   std::vector<Variable*> vars = _model->GetVariables(NULL); // all symbols that are variables
-		   BOOST_FOREACH(Variable* var, vars)
+		   for (Variable* var: vars)
 		   {
 			   std::string alt = compress_whitespace(var->Comment());
 			   if (alt == "Backlog")
@@ -537,7 +536,7 @@ SymbolList *VensimParse::SymList(SymbolList *in,Variable *add,bool bang,Variable
       }
       start.erase(i,std::string::npos) ;
       for(i=low+1;i<high;i++) {
-         finish = start + boost::lexical_cast<std::string>(i) ;
+         finish = start + std::to_string(i) ;
          v = static_cast<Variable *>(pSymbolNameSpace->Find(finish)) ;
          if(!v)
             v = new Variable(pSymbolNameSpace,finish) ;

--- a/src/Vensim/VensimView.cpp
+++ b/src/Vensim/VensimView.cpp
@@ -197,7 +197,7 @@ int VensimView::SetViewStart(int startx, int starty, int uid_start)
 		return _uid_offset;
 	int min_x = INT32_MAX;
 	int min_y = INT32_MAX;
-	BOOST_FOREACH(VensimViewElement *ele, vElements)
+	for (VensimViewElement *ele: vElements)
 	{
 		if (ele)
 		{
@@ -209,7 +209,7 @@ int VensimView::SetViewStart(int startx, int starty, int uid_start)
 	}
 	int off_x = startx - min_x;
 	int off_y = starty - min_y;
-	BOOST_FOREACH(VensimViewElement *ele, vElements)
+	for (VensimViewElement *ele: vElements)
 	{
 		if (ele)
 		{
@@ -225,7 +225,7 @@ int VensimView::GetViewMaxX(int defval)
 	if (this->vElements.empty())
 		return defval;
 	int max_x = -INT32_MAX;
-	BOOST_FOREACH(VensimViewElement *ele, vElements)
+	for (VensimViewElement *ele: vElements)
 	{
 		if (ele)
 		{
@@ -240,7 +240,7 @@ int VensimView::GetViewMaxY(int defval)
 	if (this->vElements.empty())
 		return defval;
 	int max_y = -INT32_MAX;
-	BOOST_FOREACH(VensimViewElement *ele, vElements)
+	for (VensimViewElement *ele: vElements)
 	{
 		if (ele)
 		{
@@ -253,7 +253,7 @@ int VensimView::GetViewMaxY(int defval)
 
 bool VensimView::UpgradeGhost(Variable *var)
 {
-	BOOST_FOREACH(VensimViewElement *ele, vElements)
+	for (VensimViewElement *ele: vElements)
 	{
 		if (ele && ele->Type() == VensimViewElement::ElementTypeVARIABLE)
 		{
@@ -278,7 +278,7 @@ bool VensimView::AddFlowDefinition(Variable* var, Variable* upstream, Variable* 
 	xstart = ystart = xend = yend = 0;
 	bool startfound = false;
 	bool endfound = false;
-	BOOST_FOREACH(VensimViewElement *ele, vElements)
+	for (VensimViewElement *ele: vElements)
 	{
 		if (ele && ele->Type() == VensimViewElement::ElementTypeVARIABLE)
 		{
@@ -346,7 +346,7 @@ void VensimView::CheckLinksIn()
 			if (var && var->VariableType() != XMILE_Type_STOCK && !vele->Ghost())
 			{
 				std::vector<Variable*>ins = var->GetInputVars();
-				BOOST_FOREACH(Variable* in, ins)
+				for (Variable* in: ins)
 				{
 					if (!this->FindInArrow(in, uid) && in->VariableType() != XMILE_Type_ARRAY && in->VariableType() != XMILE_Type_ARRAY_ELM && in->VariableType() != XMILE_Type_UNKNOWN)
 					{
@@ -366,7 +366,7 @@ void VensimView::CheckLinksIn()
 
 bool VensimView::FindInArrow(Variable *in, int target)
 {
-	BOOST_FOREACH(VensimViewElement* ele, this->vElements)
+	for (VensimViewElement* ele: this->vElements)
 	{
 		if (ele && ele->Type() == VensimViewElement::ElementTypeCONNECTOR)
 		{
@@ -390,7 +390,7 @@ bool VensimView::FindInArrow(Variable *in, int target)
 
 void VensimView::RemoveExtraArrowsIn(std::vector<Variable*>ins, int target)
 {
-	BOOST_FOREACH(VensimViewElement* ele, this->vElements)
+	for (VensimViewElement* ele: this->vElements)
 	{
 		if (ele && ele->Type() == VensimViewElement::ElementTypeCONNECTOR)
 		{
@@ -405,7 +405,7 @@ void VensimView::RemoveExtraArrowsIn(std::vector<Variable*>ins, int target)
 				if (from && from->Type() == VensimViewElement::ElementTypeVALVE && tele->Attached() && static_cast<VensimValveElement*>(vElements[cele->From()])->Attached())
 					from = static_cast<VensimVariableElement*>(vElements[cele->From() + 1]);
 				bool found = false;
-				BOOST_FOREACH(Variable* in, ins)
+				for (Variable* in: ins)
 				{
 					if (from->GetVariable() == in)
 					{
@@ -423,7 +423,7 @@ void VensimView::RemoveExtraArrowsIn(std::vector<Variable*>ins, int target)
 int VensimView::FindVariable(Variable *in, int x, int y)
 {
 	int uid = 0;
-	BOOST_FOREACH(VensimViewElement* ele, this->vElements)
+	for (VensimViewElement* ele: this->vElements)
 	{
 		if (ele && ele->Type() == VensimViewElement::ElementTypeVARIABLE)
 		{

--- a/src/XMUtil.cpp
+++ b/src/XMUtil.cpp
@@ -1,7 +1,6 @@
 // XMUtil.cpp : Defines the entry point for the console application.
 //
 #include <boost/filesystem.hpp>
-#include <boost/foreach.hpp>
 
 #include "Vensim/VensimParse.h"
 #include "unicode/utypes.h"
@@ -140,7 +139,7 @@ int main(int argc, char* argv[])
 	   // into flows (a single net flow on the first pass though this)
 	   m->MarkVariableTypes(NULL);
 
-	   BOOST_FOREACH(MacroFunction* mf, m->MacroFunctions())
+	   for (MacroFunction* mf: m->MacroFunctions())
 	   {
 		   m->MarkVariableTypes(mf->NameSpace());
 	   }
@@ -158,7 +157,7 @@ int main(int argc, char* argv[])
 	   std::vector<std::string> errs;
 	   m->WriteToXMILE(p.string(), errs);
 
-        BOOST_FOREACH(const std::string& err, errs)
+        for (const std::string& err: errs)
         {
             std::cout << err << std::endl;
         }

--- a/src/Xmile/XMILEGenerator.cpp
+++ b/src/Xmile/XMILEGenerator.cpp
@@ -50,7 +50,7 @@ bool XMILEGenerator::Generate(const std::string& path, std::vector<std::string>&
 	root->InsertEndChild(model);
 
 	// macros are presented as separate models
-	BOOST_FOREACH(MacroFunction* mf, _model->MacroFunctions())
+	for (MacroFunction* mf: _model->MacroFunctions())
 	{
 		tinyxml2::XMLElement* macro = doc.NewElement("macro");
 		macro->SetAttribute("name", mf->GetName().c_str());
@@ -206,7 +206,7 @@ void XMILEGenerator::generateModelUnits(tinyxml2::XMLElement* element, std::vect
 
 	std::vector<std::string>& equivs = _model->UnitEquivs();
 
-	BOOST_FOREACH(std::string& equiv, equivs)
+	for (std::string& equiv: equivs)
 	{
 		std::string name;
 		std::string eqn;
@@ -242,7 +242,7 @@ void XMILEGenerator::generateModelUnits(tinyxml2::XMLElement* element, std::vect
 			xeqn->SetText(eqn.c_str());
 			xunit->InsertEndChild(xeqn);
 		}
-		BOOST_FOREACH(std::string& alias, aliases)
+		for (std::string& alias: aliases)
 		{
 			tinyxml2::XMLElement* xalias = doc->NewElement("alias");
 			xalias->SetText(alias.c_str());
@@ -257,7 +257,7 @@ void XMILEGenerator::generateDimensions(tinyxml2::XMLElement* element, std::vect
 {
 	tinyxml2::XMLDocument* doc = element->GetDocument();
 	std::vector<Variable*> vars = _model->GetVariables(); // all symbols that are variables
-	BOOST_FOREACH(Variable* var, vars)
+	for (Variable* var: vars)
 	{
 		if (var->VariableType() == XMILE_Type_ARRAY)
 		{
@@ -285,7 +285,7 @@ void XMILEGenerator::generateDimensions(tinyxml2::XMLElement* element, std::vect
 					{
 						tinyxml2::XMLElement* xsub = doc->NewElement("dim");
 						xsub->SetAttribute("name", var->GetName().c_str());
-						BOOST_FOREACH(Symbol* s, expanded)
+						for (Symbol* s: expanded)
 						{
 							tinyxml2::XMLElement* xelm = doc->NewElement("elem");
 							xelm->SetAttribute("name", s->GetName().c_str());
@@ -307,7 +307,7 @@ void XMILEGenerator::generateModel(tinyxml2::XMLElement* element, std::vector<st
 	element->InsertEndChild(variables);
 
 	std::vector<Variable*> vars = _model->GetVariables(ns); // all symbols that are variables
-	BOOST_FOREACH(Variable * var, vars)
+	for (Variable * var: vars)
 	{
 		if (var->Unwanted())
 			continue;
@@ -354,13 +354,13 @@ void XMILEGenerator::generateModel(tinyxml2::XMLElement* element, std::vector<st
 		}
 		if (type == XMILE_Type_STOCK)
 		{
-			BOOST_FOREACH(Variable * in, var->Inflows())
+			for (Variable * in: var->Inflows())
 			{
 				tinyxml2::XMLElement* inflow = doc->NewElement("inflow");
 				xvar->InsertEndChild(inflow);
 				inflow->SetText(SpaceToUnderBar(in->GetAlternateName()).c_str());
 			}
-			BOOST_FOREACH(Variable * out, var->Outflows())
+			for (Variable * out: var->Outflows())
 			{
 				tinyxml2::XMLElement* outflow = doc->NewElement("outflow");
 				xvar->InsertEndChild(outflow);
@@ -391,7 +391,7 @@ void XMILEGenerator::generateModel(tinyxml2::XMLElement* element, std::vector<st
 					eqn->SubscriptExpand(elms, subs);
 					if (!elms.empty())
 					{
-						BOOST_FOREACH(std::vector<Symbol*> elm, elms)
+						for (std::vector<Symbol*> elm: elms)
 						{
 							for (int i = 0; i < dim_count; i++)
 							{
@@ -525,7 +525,7 @@ void XMILEGenerator::generateModel(tinyxml2::XMLElement* element, std::vector<st
 					Symbol* best = parent;
 					if (parent->Subranges() != NULL && static_cast<Variable*>(parent)->Nelm() > entry.size())
 					{
-						BOOST_FOREACH(Symbol * subrange, *parent->Subranges())
+						for (Symbol * subrange: *parent->Subranges())
 						{
 							if (static_cast<Variable*>(subrange)->Nelm() >= entry.size() &&
 								static_cast<Variable*>(subrange)->Nelm() < static_cast<Variable*>(best)->Nelm())
@@ -534,7 +534,7 @@ void XMILEGenerator::generateModel(tinyxml2::XMLElement* element, std::vector<st
 								bool complete = true;
 								std::vector<Symbol*> telms;
 								Equation::GetSubscriptElements(telms, subrange);
-								BOOST_FOREACH(Symbol * elm, entries[i])
+								for (Symbol * elm: entries[i])
 								{
 									if (std::find(telms.begin(), telms.end(), elm) == telms.end())
 									{
@@ -578,14 +578,14 @@ void XMILEGenerator::generateViews(tinyxml2::XMLElement* element, tinyxml2::XMLE
 		std::vector<ModelGroup>& groups = _model->Groups();
 		if (!groups.empty())
 		{
-			BOOST_FOREACH(ModelGroup& group, groups)
+			for (ModelGroup& group: groups)
 			{
 				tinyxml2::XMLElement* xgroup = doc->NewElement("group");
 				xgroup->SetAttribute("name", group.sName.c_str());
 				if (group.sOwner != group.sName)
 					xgroup->SetAttribute("owner", group.sOwner.c_str());
 				element->InsertEndChild(xgroup);
-				BOOST_FOREACH(Variable* var, group.vVariables)
+				for (Variable* var: group.vVariables)
 				{
 					tinyxml2::XMLElement* xvar = doc->NewElement("var");
 					xvar->SetText(SpaceToUnderBar(var->GetAlternateName()).c_str());
@@ -604,7 +604,7 @@ void XMILEGenerator::generateViews(tinyxml2::XMLElement* element, tinyxml2::XMLE
 	tinyxml2::XMLElement* xview = doc->NewElement("view");
 	element->InsertEndChild(xview);
 	int uid_off = 0;
-	BOOST_FOREACH(View* gview, views)
+	for (View* gview: views)
 	{
 		VensimView* view = static_cast<VensimView*>(gview);
 		// first update geometry - we put views one after another along the y axix - could lay out in pages or something
@@ -646,7 +646,7 @@ void XMILEGenerator::generateView(VensimView* view, tinyxml2::XMLElement* elemen
 	int uid = view->UIDOffset();
 	int local_uid = 0;
 	VensimViewElements& elements = view->Elements();
-	BOOST_FOREACH(VensimViewElement* ele, elements)
+	for (VensimViewElement* ele: elements)
 	{
 		if (ele)
 		{
@@ -737,7 +737,7 @@ void XMILEGenerator::generateView(VensimView* view, tinyxml2::XMLElement* elemen
 											if (toind == -1 && var && var->VariableType() == XMILE_Type_STOCK)
 											{
 												// are we an inflow or an outflow
-												BOOST_FOREACH(Variable* inflow, var->Inflows())
+												for (Variable* inflow: var->Inflows())
 												{
 													if (inflow == vele->GetVariable())
 													{
@@ -747,7 +747,7 @@ void XMILEGenerator::generateView(VensimView* view, tinyxml2::XMLElement* elemen
 												}
 												if (toind == -1)
 												{
-													BOOST_FOREACH(Variable* outflow, var->Outflows())
+													for (Variable* outflow: var->Outflows())
 													{
 														if (outflow == vele->GetVariable())
 														{


### PR DESCRIPTION
A number of the boost bits are now "normal" C++!  And the normal C++ is a bit easier to read, too (IMO).  There are 3 classes of changes here:
* use range-based for loops instead of `BOOST_FOREACH`
* use `std::to_string` instead of `boost:lexical_cast`
* use binary literals (e.g. `0b10`) instead of `BOOST_BINARY`

The first two are C++11, the binary literals are C++14.  The binary literal seemed to compile fine for me when telling gcc to use `-std=c++11`, but I bumped the requested version of C++ to 14 anyway.

cc @bobeberlein @wasbridge 