### PR TITLE
small fixups

### DIFF
--- a/build/bin/pylib/gyp/common.py
+++ b/build/bin/pylib/gyp/common.py
@@ -12,6 +12,12 @@ import re
 import tempfile
 import sys
 
+# Python 3.10 requires using collections.abc directly
+try:
+    MutableSet = collections.MutableSet
+except AttributeError:
+    import collections.abc
+    MutableSet = collections.abc.MutableSet
 
 # A minimal memoizing decorator. It'll blow up if the args aren't immutable,
 # among other "problems".
@@ -494,7 +500,7 @@ def uniquer(seq, idfun=None):
 
 
 # Based on http://code.activestate.com/recipes/576694/.
-class OrderedSet(collections.MutableSet):
+class OrderedSet(MutableSet):
   def __init__(self, iterable=None):
     self.end = end = []
     end += [None, end, end]         # sentinel node for doubly linked list

--- a/build/environment.sh
+++ b/build/environment.sh
@@ -3,9 +3,7 @@ if uname -a | grep -q 'MINGW'; then
 	#windows  
 	export GYP_MSVS_VERSION='2017'
 	export QTDIR="C:/Qt/x64/Qt5.11.0/5.11.0/msvc2017_64"
-else
-
-if  uname -a | grep -q 'Linux'; then
+elif  uname -a | grep -q 'Linux'; then
 	export QTDIR="$HOME/Qt5.11.0/5.11.0/gcc_64"
 else
 	#mac
@@ -15,11 +13,11 @@ else
     	export QTDIR="$HOME/Qt5.15.4/5.15.4/clang_arm64"
     fi
 
-    rm -f ./third_party/include/QtGui
+	rm -f ./third_party/include/QtGui
+	mkdir -p third_party/include
 	ln -s -f $QTDIR/lib/QtGui.framework/Headers ./third_party/include/QtGui
-    rm -f ./third_party/include/QtCore
+	rm -f ./third_party/include/QtCore
 	ln -s -f $QTDIR/lib/QtCore.framework/Headers ./third_party/include/QtCore
-    rm -f ./third_party/include/QtWidgets
+	rm -f ./third_party/include/QtWidgets
 	ln -s -f $QTDIR/lib/QtWidgets.framework/Headers ./third_party/include/QtWidgets
-fi
 fi

--- a/src/Vensim/VensimView.h
+++ b/src/Vensim/VensimView.h
@@ -86,9 +86,9 @@ public:
 	int GetNextUID();
 	VensimViewElements& Elements() { return vElements; }
 
-	bool UpgradeGhost(Variable * var);
-	bool AddFlowDefinition(Variable* var, Variable* upstream, Variable* downstream);
-	bool AddVarDefinition(Variable* var, int x, int y);
+	bool UpgradeGhost(Variable * var) override;
+	bool AddFlowDefinition(Variable* var, Variable* upstream, Variable* downstream) override;
+	bool AddVarDefinition(Variable* var, int x, int y) override;
 	virtual void CheckGhostOwners() override;
 	virtual void CheckLinksIn() override;
 	bool FindInArrow(Variable* source, int target);


### PR DESCRIPTION
Just a few commits here: 
* the first makes sure the `third_party/include` directory is created if it doesn't exist by `build/environment.sh` (a small problem I hit trying to run this on a new laptop)
* next fixes gyp to work with python 3.10, the default on some newer linux distros/homebrew
* finally mark a few new methods with `override` to quiet some harmless but verbose compiler warnings 

cc @wasbridge @bobeberlein 