### PR TITLE
cleanup file reading/writing and remove boost dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,6 @@ RUN apk add --no-cache --virtual .build-deps \
 	ninja \
 	gcc \
 	git \
-	boost-dev \
 	python2 \
 	libc-dev \
 	libgcc \
@@ -27,7 +26,6 @@ RUN ./configure.sh \
 FROM alpine:3
 
 RUN apk add --no-cache --virtual .build-deps \
-	boost-filesystem \
 	libstdc++ \
 	icu \
 	tinyxml2

--- a/README.md
+++ b/README.md
@@ -55,24 +55,6 @@ In MinGW Installation Manager make sure you've installed:
 
 ## Install dependencies
 
-### Boost C++ Libraries
-
-Download and extract the latest version of [Boost](http://www.boost.org/users/download/).
-
-Follow the instructions in [Boost Getting Started on Windows](http://www.boost.org/doc/libs/1_64_0/more/getting_started/windows.html).
-
-~~~
-cd boost
-bootstrap.bat
-bjam -j4 toolset=msvc-14.1 architecture=x86 address-model=64 --build-type=complete --with-filesystem --with-iostreams --with-system stage
-~~~
-
-The products end up in stage\lib
-The include directory is \boost
-
-Copy the headers into \third_party\include\boost
-Copy the libs into \third_party\win\lib
-
 ### ICU - International Components for Unicode
 
 Download [ICU4C](http://site.icu-project.org/download/59#TOC-ICU4C-Download)version 59.1 binaries for Win64.

--- a/XMUtil.gyp
+++ b/XMUtil.gyp
@@ -100,8 +100,11 @@
             }]
         ],
         'sources': [
+            './src/Main.cpp',
             './src/XMUtil.h',
             './src/XMUtil.cpp',
+            './src/Unicode.h',
+            './src/Unicode.cpp',
             './src/Model.h',
             './src/Model.cpp',
             './src/ContextInfo.h',

--- a/build/common.gypi
+++ b/build/common.gypi
@@ -115,7 +115,7 @@
                 'xcode_settings': {
                     'MACOSX_DEPLOYMENT_TARGET':'10.9',
                     'CLANG_CXX_LIBRARY': 'libc++',
-                    'CLANG_CXX_LANGUAGE_STANDARD': 'gnu++14',
+                    'CLANG_CXX_LANGUAGE_STANDARD': 'c++17',
                     'SDKROOT': 'macosx',
                     'GCC_OPTIMIZATION_LEVEL': '0',
                     'OTHER_CFLAGS': [
@@ -135,8 +135,6 @@
                         '-L<(cwd)/third_party/mac/lib',
                     ],
                     'libraries': [
-                        '<(cwd)/third_party/mac/lib/libboost_filesystem.a',
-                        '<(cwd)/third_party/mac/lib/libboost_iostreams.a',
                         '<(cwd)/third_party/mac/lib/libtinyxml2.a',
                         '<(cwd)/third_party/mac/lib/libicudata.a',
                         '<(cwd)/third_party/mac/lib/libicui18n.a',
@@ -147,7 +145,6 @@
                         '<(cwd)/third_party/mac/lib/libicuuc.a',
                     ]
                 }
-
             }],
             ['OS=="linux"', {
                 'defines':[
@@ -162,8 +159,6 @@
                         '-L./third_party/linux/lib',
                     ],
                     'libraries': [
-                        '-lboost_filesystem',
-                        '-lboost_iostreams',
                         '-licuuc',
                         '-ltinyxml2',
                     ],
@@ -173,7 +168,7 @@
                     '-Wall',
                     '-Wextra',
                     '-Wno-unused-parameter',
-                    '-std=c++14',
+                    '-std=c++17',
                     '-fPIC',
                 ],
                 'libraries': [

--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -123,7 +123,7 @@ int cliMain(int argc, char *argv[], Model *m) {
         return false;
     }
 
-    auto xmile = _convert_mdl_to_xmile(contents.c_str(), contents.size(), false, longNames, sectors);
+    auto xmile = _convert_mdl_to_xmile(contents.c_str(), contents.size(), path, false, longNames, sectors);
     if (xmile == nullptr) {
         fprintf(stderr, "error trying to convert the mdl to xmile\n");
         return 1;

--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -93,7 +93,7 @@ int cliMain(int argc, char *argv[], Model *m) {
         return false;
     }
 
-    auto xmile = _convert_mdl_to_xmile(contents.c_str(), contents.size(), path, false, longNames, sectors);
+    auto xmile = convert_mdl_to_xmile(contents.c_str(), contents.size(), path, false, longNames, sectors);
     if (xmile == nullptr) {
         fprintf(stderr, "error trying to convert the mdl to xmile\n");
         return 1;

--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -24,36 +24,6 @@ std::string ReadStream(std::istream &input, int &error) {
     return content;
 }
 
-std::string ReadFile(FILE *file, int &error) {
-    size_t bufLen = 0;
-    size_t bufCapacity = 4096;
-    char *buf = reinterpret_cast<char *>(malloc(bufCapacity));
-
-    while (!feof(file) && !ferror(file)) {
-        if (bufLen == bufCapacity) {
-            bufCapacity *= 2;
-            buf = reinterpret_cast<char *>(realloc(buf, bufCapacity));
-        }
-        auto len = fread(buf + bufLen, sizeof(char), bufCapacity - bufLen, file);
-        // fprintf(stderr, "read: %zu %p %zu\n", len, buf + bufLen, bufCapacity - bufLen);
-        bufLen += len;
-    }
-
-    if (!feof(file)) {
-        error = ferror(file);
-        assert(error != 0);
-        // fprintf(stderr, "ferror :\\ %d %d %s \n", error, errno, strerror(errno));
-        free(buf);
-        return "";
-    } else {
-        error = 0;
-    }
-
-    std::string str{buf, bufLen};
-    free(buf);
-    return str;
-}
-
 void cliUsage(void) {
     fprintf(
         stderr,

--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -1,0 +1,246 @@
+// XMUtil.cpp : Defines the entry point for the console application.
+//
+
+#include <algorithm>
+#include <boost/filesystem.hpp>
+#include <cstdio>
+#include <fstream>
+
+#include "Model.h"
+#include "Unicode.h"
+#include "Vensim/VensimParse.h"
+#include "XMUtil.h"
+
+#ifdef WITH_UI
+#include <QApplication>
+
+#include "UI/Main_Window.h"
+#endif
+
+static const char *argv0;
+
+std::string ReadStream(std::istream &input, int &error) {
+    std::string content{std::istreambuf_iterator<char>(input), std::istreambuf_iterator<char>()};
+
+    return content;
+}
+
+std::string ReadFile(FILE *file, int &error) {
+    size_t bufLen = 0;
+    size_t bufCapacity = 4096;
+    char *buf = reinterpret_cast<char *>(malloc(bufCapacity));
+
+    while (!feof(file) && !ferror(file)) {
+        if (bufLen == bufCapacity) {
+            bufCapacity *= 2;
+            buf = reinterpret_cast<char *>(realloc(buf, bufCapacity));
+        }
+        auto len = fread(buf + bufLen, sizeof(char), bufCapacity - bufLen, file);
+        // fprintf(stderr, "read: %zu %p %zu\n", len, buf + bufLen, bufCapacity - bufLen);
+        bufLen += len;
+    }
+
+    if (!feof(file)) {
+        error = ferror(file);
+        assert(error != 0);
+        // fprintf(stderr, "ferror :\\ %d %d %s \n", error, errno, strerror(errno));
+        free(buf);
+        return "";
+    } else {
+        error = 0;
+    }
+
+    std::string str{buf, bufLen};
+    free(buf);
+    return str;
+}
+
+void cliUsage(void) {
+    fprintf(
+        stderr,
+        "Usage: %s [OPTION...] PATH\n"
+        "Convert Vensim MDL files to XMILE.\n\n"
+        "Options:\n"
+        "  --help:\tshow this message\n"
+        "  --stdio:\tread from stdin, write to stdout\n",
+        argv0);
+
+    exit(EXIT_FAILURE);
+}
+
+int cliMain(int argc, char *argv[], Model *m) {
+    int ret = 0;
+    const char *path = nullptr;
+    bool useStdio = false;
+    bool wantComplete = false;
+    bool longNames = false;
+    bool sectors = false;
+
+    for (argv0 = argv[0], argv++, argc--; argc > 0; argv++, argc--) {
+        char const *arg = argv[0];
+        if (strcmp("--help", arg) == 0) {
+            cliUsage();
+        } else if (strcmp("--stdio", arg) == 0) {
+            useStdio = true;
+        } else if (strcmp("--want-complete", arg) == 0) {
+            wantComplete = true;
+        } else if (strcmp("--longnames", arg) == 0) {
+            longNames = true;
+        } else if (strcmp("--sectors", arg) == 0) {
+            sectors = true;
+        } else if (arg[0] == '-') {
+            fprintf(stderr, "unknown arg '%s'\n", arg);
+            cliUsage();
+        } else {
+            if (!path) {
+                path = arg;
+            } else {
+                fprintf(stderr, "specify a single path to a model\n");
+                cliUsage();
+            }
+        }
+    }
+
+    if (useStdio) {
+        path = "STDIN";
+    } else if (!useStdio && path == nullptr) {
+        fprintf(stderr, "ERROR: specify a path to a model or use --stdio\n");
+        cliUsage();
+    }
+
+    std::ifstream fileInput;
+    if (!useStdio) {
+        fileInput = std::ifstream{path, std::ios::in | std::ios::binary};
+        // couldn't open file, exit
+        if (!fileInput.is_open()) {
+            fprintf(stderr, "couldn't open file \"%s\" for reading\n", path);
+            return false;
+        }
+    }
+    int err = 0;
+    auto contents = ReadStream(useStdio ? std::cin : fileInput, err);
+    if (err) {
+        fprintf(stderr, "ReadStream(): %d (%s)\n", err, strerror(err));
+        return false;
+    }
+
+    auto xmile = _convert_mdl_to_xmile(contents.c_str(), contents.size(), false);
+    if (xmile == nullptr) {
+        fprintf(stderr, "error trying to convert the mdl to xmile\n");
+        return 1;
+    }
+
+    std::ofstream fileOutput;
+    if (!useStdio) {
+        boost::filesystem::path p(path);
+        p.replace_extension(".xmile");
+        fileOutput = std::ofstream{p.string(), std::ofstream::out | std::ios::binary | std::ios::trunc};
+        if (!fileOutput.is_open()) {
+            fprintf(stderr, "ERROR: couldn't open '%s' for writing.\n", p.string().c_str());
+            exit(EXIT_FAILURE);
+        }
+    }
+
+    (useStdio ? std::cout : fileOutput) << xmile;
+    (useStdio ? std::cout : fileOutput).flush();
+
+    return ret;
+}
+
+#ifdef _DEBUG
+void CheckMemoryTrack(int clear);
+#endif
+
+int main(int argc, char *argv[]) {
+    if (!OpenUnicode()) {
+        return -1;
+    }
+
+    int ret = 0;
+    Model *m = new Model();
+#ifndef WITH_UI
+    ret = cliMain(argc, argv, m);
+#else
+    QApplication app(argc, argv);
+    // QApplication::setWindowIcon(QIcon(":icons/icon.svg"));
+    QApplication::setOrganizationName("XMUtil");
+    QApplication::setOrganizationDomain("github.com/xmutil");
+    QApplication::setApplicationName("MDL to XMILE");
+
+    Main_Window window;
+    window.show();
+
+    ret = app.exec();
+#endif
+    delete m;
+    CloseUnicode();
+
+    // CheckMemoryTrack(1) ;
+
+    // printf("Size of symbol is %d\n",sizeof(Symbol)) ;
+    // printf("Size of variable is %d\n",sizeof(Variable)) ;
+    // _CrtDumpMemoryLeaks() ;
+
+    // if want to look at terminal
+
+    return ret;
+}
+
+#if defined(_DEBUG) && defined(wantownmemorytesting)
+#include <assert.h>
+
+#include <unordered_map>
+#undef new     // regular new used in this section
+#undef delete  // same for delete
+
+typedef struct {
+    size_t size;
+    int line_no;
+    char file[32];
+} AllocInfo;
+
+typedef std::unordered_map<void *, AllocInfo> MemTrackMap;
+
+MemTrackMap *AllocList = 0;
+
+void AddTrack(void *addr, size_t size, const char *fname, int lnum) {
+    if (!AllocList)
+        AllocList = new MemTrackMap();
+    AllocInfo ai;
+    ai.size = size;
+    ai.line_no = lnum;
+    if (strlen(fname) > 31)
+        strcpy(ai.file, fname + strlen(fname) - 31);
+    else
+        strcpy(ai.file, fname);
+    (*AllocList)[addr] = ai;
+};
+
+static int Uk = 0;
+void RemoveTrack(void *addr) {
+    if (AllocList) {
+        MemTrackMap::iterator node = AllocList->find(addr);
+        if (node != AllocList->end()) {
+            AllocList->erase(node);
+            return;
+        }
+    }
+    // printf("%x %d\n",addr,++Uk) ;
+    // ignore things that may have been allocated elsewhere - boost is not controllable
+}
+
+void CheckMemoryTrack(int clear) {
+    if (!AllocList)
+        return;
+    MemTrackMap::iterator node = AllocList->begin();
+    for (; node != AllocList->end(); node++) {
+        fprintf(stderr, "Uncleared Memory at %u size %d from %s(%d)\n", node->first, node->second.size,
+                node->second.file, node->second.line_no);
+    }
+    if (clear) {
+        MemTrackMap *a = AllocList;
+        AllocList = NULL;
+        delete a;
+    }
+}
+#endif

--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -2,8 +2,7 @@
 //
 
 #include <algorithm>
-#include <boost/filesystem.hpp>
-#include <cstdio>
+#include <filesystem>
 #include <fstream>
 
 #include "Model.h"
@@ -124,7 +123,7 @@ int cliMain(int argc, char *argv[], Model *m) {
         return false;
     }
 
-    auto xmile = _convert_mdl_to_xmile(contents.c_str(), contents.size(), false);
+    auto xmile = _convert_mdl_to_xmile(contents.c_str(), contents.size(), false, longNames, sectors);
     if (xmile == nullptr) {
         fprintf(stderr, "error trying to convert the mdl to xmile\n");
         return 1;
@@ -132,7 +131,7 @@ int cliMain(int argc, char *argv[], Model *m) {
 
     std::ofstream fileOutput;
     if (!useStdio) {
-        boost::filesystem::path p(path);
+        std::filesystem::path p(path);
         p.replace_extension(".xmile");
         fileOutput = std::ofstream{p.string(), std::ofstream::out | std::ios::binary | std::ios::trunc};
         if (!fileOutput.is_open()) {

--- a/src/Model.cpp
+++ b/src/Model.cpp
@@ -676,14 +676,7 @@ std::vector<Variable*> Model::GetVariables(SymbolNameSpace *ns)
 	return vars;
 }
 
-bool Model::WriteToXMILE(const std::string& path, std::vector<std::string>& errs)
-{
-	bool success = true;
-
-	// sim specs are different 
-
-	XMILEGenerator generator(this);
-	success = generator.Generate(path, errs, bAsSectors);
-
-	return success;
+std::string Model::PrintXMILE(bool isCompact, std::vector<std::string> &errs) {
+    XMILEGenerator generator(this);
+    return generator.Print(isCompact, errs, bAsSectors);
 }

--- a/src/Model.h
+++ b/src/Model.h
@@ -33,7 +33,7 @@ public:
    void CheckGhostOwners();
    void AttachStragglers(); // try to get diagramatic stuff right
    void MakeViewNamesUnique();
-   bool WriteToXMILE(const std::string& filePath, std::vector<std::string>& errs);
+   std::string PrintXMILE(bool isCompact, std::vector<std::string> &errs);
 
    double GetConstanValue(const char *var, double defval);
    UnitExpression* GetUnits(const char *var);

--- a/src/Symbol/SymbolNameSpace.cpp
+++ b/src/Symbol/SymbolNameSpace.cpp
@@ -1,11 +1,9 @@
 #include <assert.h>
 #include <string.h>
 
-#include "unicode/ucasemap.h"
-
 #include "SymbolNameSpace.h"
 #include "Symbol.h"
-#include "../XMUtil.h"
+#include "../Unicode.h"
 
 
 
@@ -88,13 +86,10 @@ bool SymbolNameSpace::Rename(Symbol *sym,const std::string& newname)
 // this is "not a good" string
 // which is invalid
 // 
-extern UCaseMap *GlobalUCaseMap ;
 std::string *SymbolNameSpace::ToLowerSpace(const std::string &sin)
 {
-   UErrorCode ec = U_ZERO_ERROR  ;
    int n = sin.length() ;
    char *ws = new char[2*n+2] ;
-   char *ws2 = ws + n + 1 ; // not aligned
    memcpy(ws,sin.c_str(),n) ;
    if(*ws == '\"' && ws[n-1] == '\"' && n > 1) {
       memcpy(ws,sin.c_str()+1,n-2) ;
@@ -128,16 +123,14 @@ std::string *SymbolNameSpace::ToLowerSpace(const std::string &sin)
          break ;
    }
    ws[j] = '\0';
-   ucasemap_utf8ToLower(GlobalUCaseMap, ws2, n + 1, ws, j, &ec);
-   if(ec != U_ZERO_ERROR) {
-      delete[] ws ;
-      throw "Bad unicode string" ;
+   char *ws2 = utf8ToLower(ws, j);
+   if (ws2 == nullptr) {
+     throw "Bad unicode string";
    }
    std::string *s = new std::string(ws2) ;
-   delete[] ws ;
-   return s ;
-
-         
+   delete[] ws;
+   delete[] ws2;
+   return s;
 }
 
 void SymbolNameSpace::DeleteAllUnconfirmedAllocations(void) 

--- a/src/Unicode.cpp
+++ b/src/Unicode.cpp
@@ -1,0 +1,33 @@
+// Unicode.cpp : Wraps unicode-specific functionality
+//
+#include "Unicode.h"
+
+#include "unicode/utypes.h"
+#include "unicode/ustring.h"
+#include "unicode/ucasemap.h"
+
+
+static UCaseMap *GlobalUCaseMap;
+bool OpenUnicode() {
+    UErrorCode ec = U_ZERO_ERROR;
+    GlobalUCaseMap = ucasemap_open("en",0,&ec) ;
+    return GlobalUCaseMap != nullptr;
+}
+
+void CloseUnicode() {
+   ucasemap_close(GlobalUCaseMap) ;
+}
+
+char *utf8ToLower(const char *src, size_t srcLen) {
+    char *dst = new char[srcLen+2];
+    memset(dst, 0, srcLen+2);
+
+    UErrorCode ec = U_ZERO_ERROR;
+    ucasemap_utf8ToLower(GlobalUCaseMap, dst, srcLen+1, src, srcLen, &ec);
+    if (ec != U_ZERO_ERROR) {
+      delete[] dst;
+      return nullptr;
+    }
+
+    return dst;
+}

--- a/src/Unicode.h
+++ b/src/Unicode.h
@@ -1,0 +1,13 @@
+#ifndef _XMUTIL_UNICODE_H
+#define _XMUTIL_UNICODE_H
+
+#include <cstdlib>
+
+// OpenUnicode returns true if we successfully initialized global unicode state.
+bool OpenUnicode();
+// CloseUnicode cleans up/frees global unicode state, and should only be called on program close.
+void CloseUnicode();
+
+char *utf8ToLower(const char *src, size_t srcLen);
+
+#endif

--- a/src/Vensim/VensimParse.cpp
+++ b/src/Vensim/VensimParse.cpp
@@ -224,18 +224,13 @@ static std::string compress_whitespace(const std::string& s)
 	return rval;
 }
 
-bool VensimParse::ProcessFile(const std::string &filename)
+bool VensimParse::ProcessFile(const std::string &filename, const char *contents, size_t contentsLen)
 {
    sFilename = filename ;
-    try {
-      mfSource.open(filename);
-    }
-    catch(...) {
-       return false ;
-    }
-    if(mfSource.is_open()) { 
+
+    if(true) {
        bool noerr = true ;
-       mVensimLex.Initialize((const char *)mfSource.data(), mfSource.size()) ;
+       mVensimLex.Initialize(contents, contentsLen) ;
        int endtok = mVensimLex.GetEndToken() ;
        // now we call the bison built parser which will call back to VensimLex
        // for the tokenizing - 
@@ -359,7 +354,6 @@ bool VensimParse::ProcessFile(const std::string &filename)
 			   }
 		   }
 	   }
-       mfSource.close() ;
 	   _model->SetMacroFunctions(mMacroFunctions);
 
 	   if (bLongName)

--- a/src/Vensim/VensimParse.cpp
+++ b/src/Vensim/VensimParse.cpp
@@ -1,6 +1,6 @@
 // VensimParse.cpp : Read an mdl file into an XModel object
-// we use a mapped file via boost to simplify look ahead/back
-// we include the tokenizer here because it is as easy as settinig
+// we use an in-memory string to simplify look ahead/back
+// we include the tokenizer here because it is as easy as setting
 // up regular expressions for Flex and more easily understood
 
 #include "VensimParse.h"

--- a/src/Vensim/VensimParse.h
+++ b/src/Vensim/VensimParse.h
@@ -1,7 +1,6 @@
 #ifndef _XMUTIL_VENSIM_VENSIMPARSE_H
 #define _XMUTIL_VENSIM_VENSIMPARSE_H
 #include <string>
-#include <boost/iostreams/device/mapped_file.hpp>
 #include <iostream>
 #include "../Symbol/Parse.h"
 #include "../Symbol/Symbol.h"
@@ -26,7 +25,7 @@ public:
    VensimParse(Model* model);
    ~VensimParse(void);
    void ReadyFunctions();
-   bool ProcessFile(const std::string &filename) ;
+   bool ProcessFile(const std::string &filename, const char *contents, size_t contentsLen) ;
    inline int yylex(void) { return mVensimLex.yylex() ; }
    int yyerror(const char *str) ;
    Equation *AddEq(LeftHandSide *lhs,Expression *ex,ExpressionList *exl,int tok) ;
@@ -71,7 +70,6 @@ private :
    bool FindNextEq(bool want_comment) ;
    Model* _model;
    std::string sFilename;
-   boost::iostreams::mapped_file_source mfSource;
    VensimLex mVensimLex ;
    VensimParseSyntaxError mSyntaxError ;
    SymbolNameSpace *pSymbolNameSpace ;

--- a/src/XMUtil.cpp
+++ b/src/XMUtil.cpp
@@ -292,7 +292,7 @@ double AngleFromPoints(double startx, double starty, double pointx, double point
 
 extern "C" {
 // returns NULL on error or a string containing XMILE that the caller now owns
-char *_convert_mdl_to_xmile(const char *mdlSource, uint32_t mdlSourceLen, bool isCompact, bool isLongName, bool isAsSectors) {
+char *_convert_mdl_to_xmile(const char *mdlSource, uint32_t mdlSourceLen, const char *fileName, bool isCompact, bool isLongName, bool isAsSectors) {
     Model m{};
 
     // parse the input
@@ -300,7 +300,7 @@ char *_convert_mdl_to_xmile(const char *mdlSource, uint32_t mdlSourceLen, bool i
         VensimParse vp{&m};
         vp.SetLongName(isLongName);
         m.SetAsSectors(isAsSectors);
-        if (!vp.ProcessFile("<in memory>", mdlSource, mdlSourceLen)) {
+        if (!vp.ProcessFile(fileName, mdlSource, mdlSourceLen)) {
             return nullptr;
         }
     }

--- a/src/XMUtil.cpp
+++ b/src/XMUtil.cpp
@@ -3,31 +3,14 @@
 #include <boost/filesystem.hpp>
 
 #include "Vensim/VensimParse.h"
-#include "unicode/utypes.h"
-#include "unicode/ustring.h"
-#include "unicode/ucasemap.h"
 #include "Model.h"
+#include "Unicode.h"
 #include "XMUtil.h"
 
 #ifdef WITH_UI
 #include "UI/Main_Window.h"
 #include <QApplication>
 #endif
-
-UCaseMap *GlobalUCaseMap ;
-bool OpenUCaseMap(void)
-{
-
-   UErrorCode ec = U_ZERO_ERROR  ;
-   GlobalUCaseMap = ucasemap_open("en",0,&ec) ;
-   if(!GlobalUCaseMap)
-      return false ;
-   return true ;
-}
-void CloseUCaseMap(void)
-{
-   ucasemap_close(GlobalUCaseMap) ;
-}
 
 std::string StringFromDouble(double val)
 {
@@ -94,106 +77,9 @@ bool StringMatch(const std::string& f, const std::string& s)
 }
 
 
-bool ParseVensimModel(int argc, char* argv[],Model *m)
-{
-   if(argc < 2)
-      return false ;
-   VensimParse vp(m) ;
-   char *filename = 0;
-   for (int i = 1; i < argc; i++)
-   {
-	   char *arg = argv[i];
-	   if (*arg == '-')
-	   {
-		   if (StringMatch(arg, "--longnames"))
-			   vp.SetLongName(true);
-		   else if (StringMatch(arg, "--sectors"))
-			   m->SetAsSectors(true);
-	   }
-	   else
-		   filename = arg;
-   }
-   if(!vp.ProcessFile(filename)) 
-      return false ;
-	return true ;
-}
-
 #ifdef _DEBUG
 void CheckMemoryTrack(int clear) ;
 #endif
-
-int main(int argc, char* argv[])
-{
-   if(!OpenUCaseMap())
-      return -1;
-    
-   int ret = 0;
-   Model *m = new Model() ;
-#ifndef WITH_UI
-    if(ParseVensimModel(argc,argv,m)) {
-        
-        /*if(m->AnalyzeEquations()) {
-         m->Simulate() ;
-         m->OutputComputable(true);
-      }*/
-
-	   // mark variable types and potentially convert INTEG equations involving expressions
-	   // into flows (a single net flow on the first pass though this)
-	   m->MarkVariableTypes(NULL);
-
-	   for (MacroFunction* mf: m->MacroFunctions())
-	   {
-		   m->MarkVariableTypes(mf->NameSpace());
-	   }
-
-	   // any ghosts that are never defined make the first appearance not a ghost
-	   m->CheckGhostOwners();
-
-	   // if there is a view then try to make sure everything is defined in the views
-	   // put unknowns in a heap in the first view at 20,20 but for things that have
-	   // connections try to put them in the right place
-	   bool want_complete = false; // could pass this as an option - but let the reader handle this stuff
-	   if (want_complete)
-			m->AttachStragglers();
-
-	   boost::filesystem::path p(argv[1]);
-	   p.replace_extension(".xmile");
-
-	   std::vector<std::string> errs;
-	   m->WriteToXMILE(p.string(), errs);
-
-        for (const std::string& err: errs)
-        {
-            std::cout << err << std::endl;
-        }
-    } else {
-        ret = 0;
-    }
-#else
-    QApplication app(argc, argv);
-    //QApplication::setWindowIcon(QIcon(":icons/icon.svg"));
-    QApplication::setOrganizationName("XMUtil");
-    QApplication::setOrganizationDomain("github.com/xmutil");
-    QApplication::setApplicationName("MDL to XMILE");
-    
-    Main_Window window;
-    window.show();
-    
-    ret = app.exec();
-#endif
-    delete m ;
-    CloseUCaseMap() ;
-   //CheckMemoryTrack(1) ;
-
-
-   //printf("Size of symbol is %d\n",sizeof(Symbol)) ;
-   //printf("Size of variable is %d\n",sizeof(Variable)) ;
-  // _CrtDumpMemoryLeaks() ;
-
-   // if want to look at terminal 
-
-   return ret;
-}
 
 double AngleFromPoints(double startx, double starty, double pointx, double pointy, double endx, double endy)
 {
@@ -406,63 +292,57 @@ double AngleFromPoints(double startx, double starty, double pointx, double point
 	return 33;
 }
 
-#if defined(_DEBUG) && defined(wantownmemorytesting)
-#include <unordered_map>
-#include <assert.h>
-#undef new // regular new used in this section
-#undef delete // same for delete
+extern "C" {
+// returns NULL on error or a string containing XMILE that the caller now owns
+char *_convert_mdl_to_xmile(const char *mdlSource, uint32_t mdlSourceLen, bool isCompact) {
+    Model m{};
 
-typedef struct {
-   size_t size ;
-   int line_no ;
-   char file[32] ;
-} AllocInfo ;
+    // parse the input
+    {
+        VensimParse vp{&m};
+        // vp.SetLongName(true);
+        // m.SetAsSectors(true);
+        if (!vp.ProcessFile("<in memory>", mdlSource, mdlSourceLen)) {
+            return nullptr;
+        }
+    }
 
-typedef std::unordered_map<void*, AllocInfo> MemTrackMap ;
+    // if(m->AnalyzeEquations()) {
+    //   m->Simulate() ;
+    //   m->OutputComputable(true);
+    // }
 
-MemTrackMap *AllocList = 0 ;
+    // mark variable types and potentially convert INTEG equations
+    // involving expressions into flows (a single net flow on the first
+    // pass though this)
+    m.MarkVariableTypes(nullptr);
 
-void AddTrack(void *addr,  size_t size,  const char *fname, int lnum)
-{
-   if(!AllocList)
-      AllocList = new MemTrackMap() ;
-   AllocInfo ai ;
-   ai.size = size ;
-   ai.line_no = lnum ;
-   if(strlen(fname) > 31) 
-      strcpy(ai.file,fname+strlen(fname)-31) ;
-   else
-      strcpy(ai.file,fname) ;
-   (*AllocList)[addr] = ai ;
-};
+    for (MacroFunction *mf : m.MacroFunctions()) {
+        m.MarkVariableTypes(mf->NameSpace());
+    }
 
-static int Uk =0 ;
-void RemoveTrack(void *addr)
-{
-   if(AllocList) {
-      MemTrackMap::iterator node = AllocList->find(addr) ;
-      if(node != AllocList->end()) {
-         AllocList->erase(node) ;
-         return ;
-      }
-   }
-   //printf("%x %d\n",addr,++Uk) ;
-   // ignore things that may have been allocated elsewhere - boost is not controllable
+    // any ghosts that are never defined make the first appearance not a ghost
+    m.CheckGhostOwners();
+
+    // if there is a view then try to make sure everything is defined in
+    // the views put unknowns in a heap in the first view at 20,20 but
+    // for things that have connections try to put them in the right
+    // place
+    bool want_complete = false; // could pass this as an option - but let the reader handle this stuff
+    if (want_complete) {
+        m.AttachStragglers();
+    }
+
+    // TODO: expose errs
+    std::vector<std::string> errs;
+    std::string xmile = m.PrintXMILE(isCompact, errs);
+
+    if (errs.size() != 0) {
+        return nullptr;
+    }
+
+    char *result = strdup(xmile.c_str());
+
+    return result;
 }
-
-void CheckMemoryTrack(int clear)
-{
-   if(!AllocList)
-      return ;
-   MemTrackMap::iterator node = AllocList->begin() ;
-   for(;node != AllocList->end();node++) {
-      fprintf(stderr,"Uncleared Memory at %u size %d from %s(%d)\n",node->first,node->second.size,node->second.file,node->second.line_no) ;
-   }
-   if(clear) {
-      MemTrackMap *a = AllocList ;
-      AllocList = NULL ;
-      delete a ;
-   }
 }
-
-#endif

--- a/src/XMUtil.cpp
+++ b/src/XMUtil.cpp
@@ -287,8 +287,12 @@ double AngleFromPoints(double startx, double starty, double pointx, double point
 
 extern "C" {
 // returns NULL on error or a string containing XMILE that the caller now owns
-char *_convert_mdl_to_xmile(const char *mdlSource, uint32_t mdlSourceLen, const char *fileName, bool isCompact, bool isLongName, bool isAsSectors) {
+char *convert_mdl_to_xmile(const char *mdlSource, uint32_t mdlSourceLen, const char *fileName, bool isCompact, bool isLongName, bool isAsSectors) {
     Model m{};
+
+    if (fileName == nullptr) {
+      fileName = "<in memory>";
+    }
 
     // parse the input
     {

--- a/src/XMUtil.cpp
+++ b/src/XMUtil.cpp
@@ -1,7 +1,5 @@
 // XMUtil.cpp : Defines the entry point for the console application.
 //
-#include <boost/filesystem.hpp>
-
 #include "Vensim/VensimParse.h"
 #include "Model.h"
 #include "Unicode.h"
@@ -294,14 +292,14 @@ double AngleFromPoints(double startx, double starty, double pointx, double point
 
 extern "C" {
 // returns NULL on error or a string containing XMILE that the caller now owns
-char *_convert_mdl_to_xmile(const char *mdlSource, uint32_t mdlSourceLen, bool isCompact) {
+char *_convert_mdl_to_xmile(const char *mdlSource, uint32_t mdlSourceLen, bool isCompact, bool isLongName, bool isAsSectors) {
     Model m{};
 
     // parse the input
     {
         VensimParse vp{&m};
-        // vp.SetLongName(true);
-        // m.SetAsSectors(true);
+        vp.SetLongName(isLongName);
+        m.SetAsSectors(isAsSectors);
         if (!vp.ProcessFile("<in memory>", mdlSource, mdlSourceLen)) {
             return nullptr;
         }
@@ -345,4 +343,4 @@ char *_convert_mdl_to_xmile(const char *mdlSource, uint32_t mdlSourceLen, bool i
 
     return result;
 }
-}
+} // extern "C"

--- a/src/XMUtil.cpp
+++ b/src/XMUtil.cpp
@@ -74,11 +74,6 @@ bool StringMatch(const std::string& f, const std::string& s)
 	return true;
 }
 
-
-#ifdef _DEBUG
-void CheckMemoryTrack(int clear) ;
-#endif
-
 double AngleFromPoints(double startx, double starty, double pointx, double pointy, double endx, double endy)
 {
 	double thetax;

--- a/src/XMUtil.h
+++ b/src/XMUtil.h
@@ -71,7 +71,7 @@ inline void __cdecl operator delete[](void *p)
 
 extern "C" {
 // returns NULL on error or a string containing XMILE that the caller now owns
-XMUTIL_EXPORT char *_convert_mdl_to_xmile(const char *mdlSource, uint32_t mdlSourceLen, bool isCompact);
+XMUTIL_EXPORT char *_convert_mdl_to_xmile(const char *mdlSource, uint32_t mdlSourceLen, bool isCompact, bool isLongName, bool isAsSectors);
 }
 
 

--- a/src/XMUtil.h
+++ b/src/XMUtil.h
@@ -71,7 +71,7 @@ inline void __cdecl operator delete[](void *p)
 
 extern "C" {
 // returns NULL on error or a string containing XMILE that the caller now owns
-XMUTIL_EXPORT char *_convert_mdl_to_xmile(const char *mdlSource, uint32_t mdlSourceLen, const char *fileName, bool isCompact, bool isLongName, bool isAsSectors);
+XMUTIL_EXPORT char *convert_mdl_to_xmile(const char *mdlSource, uint32_t mdlSourceLen, const char *fileName, bool isCompact, bool isLongName, bool isAsSectors);
 }
 
 

--- a/src/XMUtil.h
+++ b/src/XMUtil.h
@@ -63,6 +63,18 @@ inline void __cdecl operator delete[](void *p)
 #endif
 #endif
 
+#ifdef WIN32
+#define XMUTIL_EXPORT
+#else
+#define XMUTIL_EXPORT __attribute__((visibility("default")))
+#endif
+
+extern "C" {
+// returns NULL on error or a string containing XMILE that the caller now owns
+XMUTIL_EXPORT char *_convert_mdl_to_xmile(const char *mdlSource, uint32_t mdlSourceLen, bool isCompact);
+}
+
+
 // utility functions
 std::string StringFromDouble(double val);
 std::string SpaceToUnderBar(const std::string& s);

--- a/src/XMUtil.h
+++ b/src/XMUtil.h
@@ -71,7 +71,7 @@ inline void __cdecl operator delete[](void *p)
 
 extern "C" {
 // returns NULL on error or a string containing XMILE that the caller now owns
-XMUTIL_EXPORT char *_convert_mdl_to_xmile(const char *mdlSource, uint32_t mdlSourceLen, bool isCompact, bool isLongName, bool isAsSectors);
+XMUTIL_EXPORT char *_convert_mdl_to_xmile(const char *mdlSource, uint32_t mdlSourceLen, const char *fileName, bool isCompact, bool isLongName, bool isAsSectors);
 }
 
 

--- a/src/Xmile/XMILEGenerator.cpp
+++ b/src/Xmile/XMILEGenerator.cpp
@@ -19,6 +19,7 @@ std::string XMILEGenerator::Print(bool is_compact, std::vector<std::string>& err
 	tinyxml2::XMLElement* root = doc.NewElement("xmile");
 	root->SetName("xmile");
 	root->SetAttribute("xmlns", "http://docs.oasis-open.org/xmile/ns/XMILE/v1.0");
+	root->SetAttribute("xmlns:isee", "http://iseesystems.com/XMILE");
 	root->SetAttribute("version", "1.0");
 	doc.InsertFirstChild(root);
 

--- a/src/Xmile/XMILEGenerator.cpp
+++ b/src/Xmile/XMILEGenerator.cpp
@@ -12,7 +12,7 @@ XMILEGenerator::XMILEGenerator(Model* model)
 	_model = model;
 }
 
-bool XMILEGenerator::Generate(const std::string& path, std::vector<std::string>& errs, bool as_sectors)
+std::string XMILEGenerator::Print(bool is_compact, std::vector<std::string>& errs, bool as_sectors)
 {
 	tinyxml2::XMLDocument doc;
 	
@@ -81,18 +81,17 @@ bool XMILEGenerator::Generate(const std::string& path, std::vector<std::string>&
 		root->InsertEndChild(macro);
 	}
 
-	tinyxml2::XMLError err = doc.SaveFile(path.c_str());
-	if (err != tinyxml2::XML_SUCCESS)
-	{
- 		if (doc.ErrorStr())
+	tinyxml2::XMLPrinter printer{nullptr, is_compact};
+	if (!doc.Accept(&printer)) {
+		if (doc.ErrorStr()) {
 			errs.push_back("TinyXML2 Error: " + std::string(doc.ErrorStr()));
-		else
-			errs.push_back("File error opening document");
-
-		return false;
+		}
+		return "";
 	}
-	
-	return true;
+
+	std::string xmile = printer.CStr();
+
+	return xmile;
 }
 
 void XMILEGenerator::generateHeader(tinyxml2::XMLElement* element, std::vector<std::string>& errs)

--- a/src/Xmile/XMILEGenerator.h
+++ b/src/Xmile/XMILEGenerator.h
@@ -17,7 +17,7 @@ class XMILEGenerator
 public:
 	XMILEGenerator(Model* model);
 
-	bool Generate(const std::string& path, std::vector<std::string>& errs, bool as_sectors);
+	std::string Print(bool is_compact, std::vector<std::string>& errs, bool as_sectors);
 
 protected:
 	void generateHeader(tinyxml2::XMLElement* element, std::vector<std::string>& errs);


### PR DESCRIPTION
Very open to requests for changes/approach here! 

In general this does a few things:
* I pulled out `main()` from XMUtil.cpp (where it lived with some other utility functions) into `Main.cpp`, and added `--help` text (and tried to make it a bit more robust/verbose if something goes wrong when invoking the command-line version)
* Moved all the unicode parts into a single file
* Removed the final dependencies on boost (primarily this was by using C++17's `filesystem` library rather than the boost one).  This seems to be supported since Visual Studio 2019 and ~ 2018 Xcode.
* defined the `xmile:isee` namespace, like Stella seems to do (since things like save_step use the `isee:` prefix, seems like the most correct thing to do)
* move a bunch of main's logic to the `extern "C"` function `_convert_mdl_to_xmile`, which makes the bulk of the codebase usable as a shared or static library!

cc @wasbridge @bobeberlein 