### PR TITLE
add `log` abstraction over `printf`/`cout`

### DIFF
--- a/XMUtil.gyp
+++ b/XMUtil.gyp
@@ -103,6 +103,8 @@
             './src/Main.cpp',
             './src/XMUtil.h',
             './src/XMUtil.cpp',
+            './src/Log.h',
+            './src/Log.cpp',
             './src/Unicode.h',
             './src/Unicode.cpp',
             './src/Model.h',

--- a/src/ContextInfo.h
+++ b/src/ContextInfo.h
@@ -2,7 +2,7 @@
 #define _XMUTIL_CONTEXTINFO_H
 #include <vector>
 #include <sstream>
-#include <assert.h>
+#include <cassert>
 /* a utility class helpfu in sorting and evaluating equations 
 */
 

--- a/src/Log.cpp
+++ b/src/Log.cpp
@@ -1,0 +1,31 @@
+#include <cstdarg>
+#include <cstdio>
+#include <cstdlib>
+
+#include "Log.h"
+
+#ifdef WIN32
+#define ATTRIBUTE_PRINTF
+#else
+// this gives us better compiler error messages for callers
+#define ATTRIBUTE_PRINTF __attribute__ ((format(printf, 1, 2)))
+#endif
+
+void ATTRIBUTE_PRINTF
+log(const char *msg_fmt, ...) {
+    char *msg;
+    va_list args;
+    int ret;
+
+    va_start(args, msg_fmt);
+    ret = vasprintf(&msg, msg_fmt, args);
+    va_end(args);
+
+    if (ret == -1) {
+        fprintf(stderr, "log: vasprintf failed.\n");
+    } else {
+        fprintf(stderr, "%s\n", msg);
+    }
+
+    free(msg);
+}

--- a/src/Log.h
+++ b/src/Log.h
@@ -1,0 +1,10 @@
+// Log.h - functions for emitting logging information - wraps writing to stderr.
+#ifndef _XMUTIL_LOG_H
+#define _XMUTIL_LOG_H
+
+// for use by bison-generated parser
+#define XmutilLogf(file, msgFmt, args...) log(msgFmt, ## args)
+
+void log(const char *msgFmt, ...);
+
+#endif

--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -2,8 +2,10 @@
 //
 
 #include <algorithm>
+#include <cstring>
 #include <filesystem>
 #include <fstream>
+#include <iostream>
 
 #include "Model.h"
 #include "Unicode.h"
@@ -24,10 +26,8 @@ std::string ReadStream(std::istream &input, int &error) {
     return content;
 }
 
-void cliUsage(void) {
-    fprintf(
-        stderr,
-        "Usage: %s [OPTION...] PATH\n"
+void cliUsage() {
+    log("Usage: %s [OPTION...] PATH\n"
         "Convert Vensim MDL files to XMILE.\n\n"
         "Options:\n"
         "  --help:\tshow this message\n"
@@ -58,13 +58,13 @@ int cliMain(int argc, char *argv[], Model *m) {
         } else if (strcmp("--sectors", arg) == 0) {
             sectors = true;
         } else if (arg[0] == '-') {
-            fprintf(stderr, "unknown arg '%s'\n", arg);
+            log("unknown arg '%s'\n", arg);
             cliUsage();
         } else {
             if (!path) {
                 path = arg;
             } else {
-                fprintf(stderr, "specify a single path to a model\n");
+                log("specify a single path to a model\n");
                 cliUsage();
             }
         }
@@ -73,7 +73,7 @@ int cliMain(int argc, char *argv[], Model *m) {
     if (useStdio) {
         path = "STDIN";
     } else if (!useStdio && path == nullptr) {
-        fprintf(stderr, "ERROR: specify a path to a model or use --stdio\n");
+        log("ERROR: specify a path to a model or use --stdio\n");
         cliUsage();
     }
 
@@ -82,20 +82,20 @@ int cliMain(int argc, char *argv[], Model *m) {
         fileInput = std::ifstream{path, std::ios::in | std::ios::binary};
         // couldn't open file, exit
         if (!fileInput.is_open()) {
-            fprintf(stderr, "couldn't open file \"%s\" for reading\n", path);
+            log("couldn't open file \"%s\" for reading\n", path);
             return false;
         }
     }
     int err = 0;
     auto contents = ReadStream(useStdio ? std::cin : fileInput, err);
     if (err) {
-        fprintf(stderr, "ReadStream(): %d (%s)\n", err, strerror(err));
+        log("ReadStream(): %d (%s)\n", err, strerror(err));
         return false;
     }
 
     auto xmile = convert_mdl_to_xmile(contents.c_str(), contents.size(), path, false, longNames, sectors);
     if (xmile == nullptr) {
-        fprintf(stderr, "error trying to convert the mdl to xmile\n");
+        log("error trying to convert the mdl to xmile\n");
         return 1;
     }
 
@@ -105,7 +105,7 @@ int cliMain(int argc, char *argv[], Model *m) {
         p.replace_extension(".xmile");
         fileOutput = std::ofstream{p.string(), std::ofstream::out | std::ios::binary | std::ios::trunc};
         if (!fileOutput.is_open()) {
-            fprintf(stderr, "ERROR: couldn't open '%s' for writing.\n", p.string().c_str());
+            log("ERROR: couldn't open '%s' for writing.\n", p.string().c_str());
             exit(EXIT_FAILURE);
         }
     }
@@ -146,8 +146,8 @@ int main(int argc, char *argv[]) {
 
     // CheckMemoryTrack(1) ;
 
-    // printf("Size of symbol is %d\n",sizeof(Symbol)) ;
-    // printf("Size of variable is %d\n",sizeof(Variable)) ;
+    // log("Size of symbol is %d\n",sizeof(Symbol)) ;
+    // log("Size of variable is %d\n",sizeof(Variable)) ;
     // _CrtDumpMemoryLeaks() ;
 
     // if want to look at terminal
@@ -194,7 +194,7 @@ void RemoveTrack(void *addr) {
             return;
         }
     }
-    // printf("%x %d\n",addr,++Uk) ;
+    // log("%x %d\n",addr,++Uk) ;
     // ignore things that may have been allocated elsewhere - boost is not controllable
 }
 
@@ -203,7 +203,7 @@ void CheckMemoryTrack(int clear) {
         return;
     MemTrackMap::iterator node = AllocList->begin();
     for (; node != AllocList->end(); node++) {
-        fprintf(stderr, "Uncleared Memory at %u size %d from %s(%d)\n", node->first, node->second.size,
+        log("Uncleared Memory at %u size %d from %s(%d)\n", node->first, node->second.size,
                 node->second.file, node->second.line_no);
     }
     if (clear) {

--- a/src/Symbol/Variable.cpp
+++ b/src/Symbol/Variable.cpp
@@ -123,7 +123,7 @@ XMILE_Type Variable::MarkFlows(SymbolNameSpace* sns)
 				const std::vector<double>& vals = t->GetVals();
 				if (vals.size() != elms.size())
 				{
-					std::cout << "Error the number of entries does not match array size for \"" << this->GetName() << std::endl;
+					log("Error the number of entries does not match array size for \"%s\"\n", this->GetName().c_str());
 				}
 				else
 				{
@@ -338,9 +338,9 @@ void VariableContentVar::CheckPlaceholderVars(Model *m)
 
 bool VariableContentVar::CheckComputed(Symbol *parent,ContextInfo *info,bool first)
 {
-   //printf("Checking out %s\n",GetName().c_str()) ;
+   //log("Checking out %s\n",GetName().c_str()) ;
    if(!pState) {
-      //printf("   - not computable ignoring\n") ;
+      //log("   - not computable ignoring\n") ;
       return true ;
    }
    if(pState->cComputeFlag & info->GetComputeType()) {
@@ -355,20 +355,20 @@ bool VariableContentVar::CheckComputed(Symbol *parent,ContextInfo *info,bool fir
    int intype = info->GetComputeType() << 1 ;
    if(pState->cComputeFlag & intype) {
       if(info->GetComputeType() == CF_initial)
-         std::cout << "Simultaneous initial equations found " << std::endl ;
+         log("Simultaneous initial equations found \n");
       else {
          if(pState->HasMemory()) { // first call was for rates - now for level
             assert(!first) ;
             info->AddDDF(DDF_level) ;
             return true ;
          }
-         std::cout << "Simultaneous active equations found " << std::endl ;
+         log("Simultaneous active equations found \n");
       }
-      std::cout << "     " << parent->GetName() << std::endl ;
+      log("     %s\n", parent->GetName().c_str());
       pState->cComputeFlag &= ~intype ;
       return false ;
    } else if(!first && (info->GetComputeType() != CF_initial) && pState->HasMemory()) {
-      //printf("Not tracing further for level  %s\n",GetName().c_str()) ;
+      //log("Not tracing further for level  %s\n",GetName().c_str()) ;
       info->AddDDF(DDF_level) ; // this is the level - even if the rate is a constant (only a 0 rate would really be unchanging)
       return true ;
    } else if(first && info->GetComputeType() == CF_initial && !pState->HasMemory()) {
@@ -383,7 +383,7 @@ bool VariableContentVar::CheckComputed(Symbol *parent,ContextInfo *info,bool fir
       pState->cComputeFlag |= intype ;
       for (Equation* e: vEquations) {
          if(!e->GetExpression()->CheckComputed(info)) {
-            std::cout << "     " << parent->GetName() << std::endl ;
+            log("     %s\n", parent->GetName().c_str());
             pState->cComputeFlag &= ~intype ;
             pState->cComputeFlag |= info->GetComputeType() ; // don't reenter
             return false ;
@@ -410,7 +410,7 @@ bool VariableContentVar::CheckComputed(Symbol *parent,ContextInfo *info,bool fir
       if(!pState->HasMemory())
          return true ;
    }
-   printf("Outputting equations for  %s\n",parent->GetName().c_str()) ;
+   log("Outputting equations for  %s\n",parent->GetName().c_str()) ;
    for (Equation* e: vEquations) {
       info->PushEquation(e) ;
    }

--- a/src/Unicode.cpp
+++ b/src/Unicode.cpp
@@ -1,5 +1,7 @@
 // Unicode.cpp : Wraps unicode-specific functionality
-//
+
+#include <cstring>
+
 #include "Unicode.h"
 
 #include "unicode/utypes.h"

--- a/src/Vensim/VYacc.tab.cpp
+++ b/src/Vensim/VYacc.tab.cpp
@@ -76,13 +76,15 @@
 /* First part of user prologue.  */
 #line 10 "VYacc.y"
 
+#include "../Log.h"
 #include "../Symbol/Parse.h"
 #include "VensimParseFunctions.h"
 extern int vpyylex (void);
 extern void vpyyerror (char const *);
 #define YYSTYPE ParseUnion
+#define YYFPRINTF XmutilLogf
 
-#line 86 "VYacc.tab.cpp"
+#line 88 "VYacc.tab.cpp"
 
 # ifndef YY_CAST
 #  ifdef __cplusplus
@@ -575,16 +577,16 @@ static const yytype_int8 yytranslate[] =
 /* YYRLINE[YYN] -- Source line where rule number YYN was defined.  */
 static const yytype_int16 yyrline[] =
 {
-       0,    86,    86,    87,    88,    89,    90,    91,    92,    93,
-      97,    97,   101,   108,   109,   110,   111,   112,   113,   114,
-     115,   116,   121,   122,   123,   127,   128,   132,   136,   137,
-     138,   139,   142,   143,   144,   145,   149,   150,   151,   152,
-     153,   157,   158,   161,   162,   163,   167,   168,   169,   170,
-     175,   176,   177,   178,   182,   183,   187,   188,   189,   190,
-     195,   196,   201,   202,   203,   204,   208,   209,   210,   211,
-     212,   213,   214,   215,   216,   217,   218,   219,   220,   221,
-     222,   223,   224,   225,   226,   227,   228,   229,   230,   231,
-     232,   236,   237,   239,   244,   245,   250,   251,   256,   257
+       0,    88,    88,    89,    90,    91,    92,    93,    94,    95,
+      99,    99,   103,   110,   111,   112,   113,   114,   115,   116,
+     117,   118,   123,   124,   125,   129,   130,   134,   138,   139,
+     140,   141,   144,   145,   146,   147,   151,   152,   153,   154,
+     155,   159,   160,   163,   164,   165,   169,   170,   171,   172,
+     177,   178,   179,   180,   184,   185,   189,   190,   191,   192,
+     197,   198,   203,   204,   205,   206,   210,   211,   212,   213,
+     214,   215,   216,   217,   218,   219,   220,   221,   222,   223,
+     224,   225,   226,   227,   228,   229,   230,   231,   232,   233,
+     234,   238,   239,   241,   246,   247,   252,   253,   258,   259
 };
 #endif
 
@@ -1306,595 +1308,595 @@ yyreduce:
   switch (yyn)
     {
   case 2: /* fulleq: VPTT_eqend  */
-#line 86 "VYacc.y"
+#line 88 "VYacc.y"
                    { return VPTT_eqend ; }
-#line 1312 "VYacc.tab.cpp"
+#line 1314 "VYacc.tab.cpp"
     break;
 
   case 3: /* fulleq: VPTT_groupstar  */
-#line 87 "VYacc.y"
+#line 89 "VYacc.y"
                          { return VPTT_groupstar ; }
-#line 1318 "VYacc.tab.cpp"
+#line 1320 "VYacc.tab.cpp"
     break;
 
   case 4: /* fulleq: macrostart  */
-#line 88 "VYacc.y"
+#line 90 "VYacc.y"
                                   { return '|'; }
-#line 1324 "VYacc.tab.cpp"
+#line 1326 "VYacc.tab.cpp"
     break;
 
   case 5: /* fulleq: macroend  */
-#line 89 "VYacc.y"
+#line 91 "VYacc.y"
                                           {return '|'; }
-#line 1330 "VYacc.tab.cpp"
+#line 1332 "VYacc.tab.cpp"
     break;
 
   case 6: /* fulleq: eqn '~' unitsrange '~'  */
-#line 90 "VYacc.y"
+#line 92 "VYacc.y"
                                                       {vpyy_addfulleq((yyvsp[-3].eqn),(yyvsp[-1].uni)) ; return '~' ; }
-#line 1336 "VYacc.tab.cpp"
+#line 1338 "VYacc.tab.cpp"
     break;
 
   case 7: /* fulleq: eqn '~' unitsrange '|'  */
-#line 91 "VYacc.y"
+#line 93 "VYacc.y"
                                                        {vpyy_addfulleq((yyvsp[-3].eqn),(yyvsp[-1].uni)) ; return '|' ; }
-#line 1342 "VYacc.tab.cpp"
+#line 1344 "VYacc.tab.cpp"
     break;
 
   case 8: /* fulleq: eqn '~' '~'  */
-#line 92 "VYacc.y"
+#line 94 "VYacc.y"
                                          {vpyy_addfulleq((yyvsp[-2].eqn),NULL) ; return '~' ;}
-#line 1348 "VYacc.tab.cpp"
+#line 1350 "VYacc.tab.cpp"
     break;
 
   case 9: /* fulleq: eqn '~' '|'  */
-#line 93 "VYacc.y"
+#line 95 "VYacc.y"
                                                    {vpyy_addfulleq((yyvsp[-2].eqn),NULL) ; return '|' ;}
-#line 1354 "VYacc.tab.cpp"
+#line 1356 "VYacc.tab.cpp"
     break;
 
   case 10: /* $@1: %empty  */
-#line 97 "VYacc.y"
+#line 99 "VYacc.y"
                    { vpyy_macro_start(); }
-#line 1360 "VYacc.tab.cpp"
+#line 1362 "VYacc.tab.cpp"
     break;
 
   case 11: /* macrostart: VPTT_macro $@1 VPTT_symbol '(' exprlist ')'  */
-#line 97 "VYacc.y"
+#line 99 "VYacc.y"
                                                                           { vpyy_macro_expression((yyvsp[-3].sym),(yyvsp[-1].exl)) ;}
-#line 1366 "VYacc.tab.cpp"
+#line 1368 "VYacc.tab.cpp"
     break;
 
   case 12: /* macroend: VPTT_end_of_macro  */
-#line 101 "VYacc.y"
+#line 103 "VYacc.y"
                      { (yyval.tok) = (yyvsp[0].tok); vpyy_macro_end(); }
-#line 1372 "VYacc.tab.cpp"
+#line 1374 "VYacc.tab.cpp"
     break;
 
   case 13: /* eqn: lhs '=' exprlist  */
-#line 108 "VYacc.y"
+#line 110 "VYacc.y"
                     {(yyval.eqn) = vpyy_addeq((yyvsp[-2].lhs),NULL,(yyvsp[0].exl),'=') ; }
-#line 1378 "VYacc.tab.cpp"
+#line 1380 "VYacc.tab.cpp"
     break;
 
   case 14: /* eqn: lhs '(' tablevals ')'  */
-#line 109 "VYacc.y"
+#line 111 "VYacc.y"
                            { (yyval.eqn) = vpyy_add_lookup((yyvsp[-3].lhs),NULL,(yyvsp[-1].tbl), 0) ; }
-#line 1384 "VYacc.tab.cpp"
+#line 1386 "VYacc.tab.cpp"
     break;
 
   case 15: /* eqn: lhs '(' xytablevals ')'  */
-#line 110 "VYacc.y"
+#line 112 "VYacc.y"
                              { (yyval.eqn) = vpyy_add_lookup((yyvsp[-3].lhs),NULL,(yyvsp[-1].tbl), 1) ; }
-#line 1390 "VYacc.tab.cpp"
+#line 1392 "VYacc.tab.cpp"
     break;
 
   case 16: /* eqn: lhs '=' VPTT_with_lookup '(' exp ',' '(' tablevals ')' ')'  */
-#line 111 "VYacc.y"
+#line 113 "VYacc.y"
                                                                 { (yyval.eqn) = vpyy_add_lookup((yyvsp[-9].lhs),(yyvsp[-5].exn),(yyvsp[-2].tbl), 0) ; }
-#line 1396 "VYacc.tab.cpp"
+#line 1398 "VYacc.tab.cpp"
     break;
 
   case 17: /* eqn: lhs VPTT_dataequals exp  */
-#line 112 "VYacc.y"
+#line 114 "VYacc.y"
                              {(yyval.eqn) = vpyy_addeq((yyvsp[-2].lhs),(yyvsp[0].exn),NULL,VPTT_dataequals) ; }
-#line 1402 "VYacc.tab.cpp"
+#line 1404 "VYacc.tab.cpp"
     break;
 
   case 18: /* eqn: lhs  */
-#line 113 "VYacc.y"
+#line 115 "VYacc.y"
          { (yyval.eqn) = vpyy_add_lookup((yyvsp[0].lhs),NULL,NULL, 0) ; }
-#line 1408 "VYacc.tab.cpp"
+#line 1410 "VYacc.tab.cpp"
     break;
 
   case 19: /* eqn: VPTT_symbol ':' subdef maplist  */
-#line 114 "VYacc.y"
+#line 116 "VYacc.y"
                                     {(yyval.eqn) = vpyy_addeq(vpyy_addexceptinterp(vpyy_var_expression((yyvsp[-3].sym),NULL),NULL,0),(Expression *)vpyy_symlist_expression((yyvsp[-1].sml),(yyvsp[0].sml)),NULL,':') ; }
-#line 1414 "VYacc.tab.cpp"
+#line 1416 "VYacc.tab.cpp"
     break;
 
   case 20: /* eqn: VPTT_symbol VPTT_equiv VPTT_symbol  */
-#line 115 "VYacc.y"
+#line 117 "VYacc.y"
                                          {(yyval.eqn) = vpyy_addeq(vpyy_addexceptinterp(vpyy_var_expression((yyvsp[-2].sym),NULL),NULL,0),(Expression *)vpyy_symlist_expression(vpyy_symlist(NULL,(yyvsp[0].sym),0,NULL),NULL),NULL,VPTT_equiv) ; }
-#line 1420 "VYacc.tab.cpp"
+#line 1422 "VYacc.tab.cpp"
     break;
 
   case 21: /* eqn: lhs '=' VPTT_tabbed_array  */
-#line 116 "VYacc.y"
+#line 118 "VYacc.y"
                                { (yyval.eqn) = vpyy_addeq((yyvsp[-2].lhs),(yyvsp[0].exn),NULL,'=') ; }
-#line 1426 "VYacc.tab.cpp"
+#line 1428 "VYacc.tab.cpp"
     break;
 
   case 22: /* lhs: var  */
-#line 121 "VYacc.y"
+#line 123 "VYacc.y"
         { (yyval.lhs) = vpyy_addexceptinterp((yyvsp[0].var),NULL,0) ; }
-#line 1432 "VYacc.tab.cpp"
+#line 1434 "VYacc.tab.cpp"
     break;
 
   case 23: /* lhs: var exceptlist  */
-#line 122 "VYacc.y"
+#line 124 "VYacc.y"
                      {(yyval.lhs) = vpyy_addexceptinterp((yyvsp[-1].var),(yyvsp[0].sll),0) ;}
-#line 1438 "VYacc.tab.cpp"
+#line 1440 "VYacc.tab.cpp"
     break;
 
   case 24: /* lhs: var interpmode  */
-#line 123 "VYacc.y"
+#line 125 "VYacc.y"
                     {(yyval.lhs) = vpyy_addexceptinterp((yyvsp[-1].var),NULL,(yyvsp[0].tok)) ;}
-#line 1444 "VYacc.tab.cpp"
+#line 1446 "VYacc.tab.cpp"
     break;
 
   case 25: /* var: VPTT_symbol  */
-#line 127 "VYacc.y"
+#line 129 "VYacc.y"
                     { (yyval.var) = vpyy_var_expression((yyvsp[0].sym),NULL);}
-#line 1450 "VYacc.tab.cpp"
+#line 1452 "VYacc.tab.cpp"
     break;
 
   case 26: /* var: VPTT_symbol sublist  */
-#line 128 "VYacc.y"
+#line 130 "VYacc.y"
                               { (yyval.var) = vpyy_var_expression((yyvsp[-1].sym),(yyvsp[0].sml)) ;}
-#line 1456 "VYacc.tab.cpp"
+#line 1458 "VYacc.tab.cpp"
     break;
 
   case 27: /* sublist: '[' symlist ']'  */
-#line 132 "VYacc.y"
+#line 134 "VYacc.y"
                         {(yyval.sml) = (yyvsp[-1].sml) ;}
-#line 1462 "VYacc.tab.cpp"
+#line 1464 "VYacc.tab.cpp"
     break;
 
   case 28: /* symlist: VPTT_symbol  */
-#line 136 "VYacc.y"
+#line 138 "VYacc.y"
                     { (yyval.sml) = vpyy_symlist(NULL,(yyvsp[0].sym),0,NULL) ; }
-#line 1468 "VYacc.tab.cpp"
+#line 1470 "VYacc.tab.cpp"
     break;
 
   case 29: /* symlist: VPTT_symbol '!'  */
-#line 137 "VYacc.y"
+#line 139 "VYacc.y"
                           { (yyval.sml) = vpyy_symlist(NULL,(yyvsp[-1].sym),1,NULL) ; }
-#line 1474 "VYacc.tab.cpp"
+#line 1476 "VYacc.tab.cpp"
     break;
 
   case 30: /* symlist: symlist ',' VPTT_symbol  */
-#line 138 "VYacc.y"
+#line 140 "VYacc.y"
                                   { (yyval.sml) = vpyy_symlist((yyvsp[-2].sml),(yyvsp[0].sym),0,NULL) ;}
-#line 1480 "VYacc.tab.cpp"
+#line 1482 "VYacc.tab.cpp"
     break;
 
   case 31: /* symlist: symlist ',' VPTT_symbol '!'  */
-#line 139 "VYacc.y"
+#line 141 "VYacc.y"
                                       { (yyval.sml) = vpyy_symlist((yyvsp[-3].sml),(yyvsp[-1].sym),1,NULL) ;}
-#line 1486 "VYacc.tab.cpp"
+#line 1488 "VYacc.tab.cpp"
     break;
 
   case 32: /* subdef: VPTT_symbol  */
-#line 142 "VYacc.y"
+#line 144 "VYacc.y"
                     { (yyval.sml) = vpyy_symlist(NULL,(yyvsp[0].sym),0,NULL) ; }
-#line 1492 "VYacc.tab.cpp"
+#line 1494 "VYacc.tab.cpp"
     break;
 
   case 33: /* subdef: '(' VPTT_symbol '-' VPTT_symbol ')'  */
-#line 143 "VYacc.y"
+#line 145 "VYacc.y"
                                               {(yyval.sml) = vpyy_symlist(NULL,(yyvsp[-3].sym),0,(yyvsp[-1].sym)) ;}
-#line 1498 "VYacc.tab.cpp"
+#line 1500 "VYacc.tab.cpp"
     break;
 
   case 34: /* subdef: subdef ',' VPTT_symbol  */
-#line 144 "VYacc.y"
+#line 146 "VYacc.y"
                                  { (yyval.sml) = vpyy_symlist((yyvsp[-2].sml),(yyvsp[0].sym),0,NULL) ; }
-#line 1504 "VYacc.tab.cpp"
+#line 1506 "VYacc.tab.cpp"
     break;
 
   case 35: /* subdef: subdef ',' '(' VPTT_symbol '-' VPTT_symbol ')'  */
-#line 145 "VYacc.y"
+#line 147 "VYacc.y"
                                                          {(yyval.sml) = vpyy_symlist((yyvsp[-6].sml),(yyvsp[-3].sym),0,(yyvsp[-1].sym)) ; }
-#line 1510 "VYacc.tab.cpp"
+#line 1512 "VYacc.tab.cpp"
     break;
 
   case 36: /* unitsrange: units  */
-#line 149 "VYacc.y"
+#line 151 "VYacc.y"
               { (yyval.uni) = (yyvsp[0].uni) ; }
-#line 1516 "VYacc.tab.cpp"
+#line 1518 "VYacc.tab.cpp"
     break;
 
   case 37: /* unitsrange: units '[' urangenum ',' urangenum ']'  */
-#line 150 "VYacc.y"
+#line 152 "VYacc.y"
                                                 { (yyval.uni) = vpyy_unitsrange((yyvsp[-5].uni),(yyvsp[-3].num),(yyvsp[-1].num),-1) ; }
-#line 1522 "VYacc.tab.cpp"
+#line 1524 "VYacc.tab.cpp"
     break;
 
   case 38: /* unitsrange: units '[' urangenum ',' urangenum ',' urangenum ']'  */
-#line 151 "VYacc.y"
+#line 153 "VYacc.y"
                                                               { (yyval.uni) = vpyy_unitsrange((yyvsp[-7].uni),(yyvsp[-5].num),(yyvsp[-3].num),(yyvsp[-1].num)) ; }
-#line 1528 "VYacc.tab.cpp"
+#line 1530 "VYacc.tab.cpp"
     break;
 
   case 39: /* unitsrange: '[' urangenum ',' urangenum ']'  */
-#line 152 "VYacc.y"
+#line 154 "VYacc.y"
                                           { (yyval.uni) = vpyy_unitsrange(NULL,(yyvsp[-3].num),(yyvsp[-1].num),-1) ; }
-#line 1534 "VYacc.tab.cpp"
+#line 1536 "VYacc.tab.cpp"
     break;
 
   case 40: /* unitsrange: '[' urangenum ',' urangenum ',' urangenum ']'  */
-#line 153 "VYacc.y"
+#line 155 "VYacc.y"
                                                         { (yyval.uni) = vpyy_unitsrange(NULL,(yyvsp[-5].num),(yyvsp[-3].num),(yyvsp[-1].num)) ; }
-#line 1540 "VYacc.tab.cpp"
+#line 1542 "VYacc.tab.cpp"
     break;
 
   case 41: /* urangenum: number  */
-#line 157 "VYacc.y"
+#line 159 "VYacc.y"
                {(yyval.num) = (yyvsp[0].num) ; }
-#line 1546 "VYacc.tab.cpp"
+#line 1548 "VYacc.tab.cpp"
     break;
 
   case 42: /* urangenum: '?'  */
-#line 158 "VYacc.y"
+#line 160 "VYacc.y"
               {(yyval.num) = -1e30 ; }
-#line 1552 "VYacc.tab.cpp"
+#line 1554 "VYacc.tab.cpp"
     break;
 
   case 43: /* number: VPTT_number  */
-#line 161 "VYacc.y"
+#line 163 "VYacc.y"
                     {(yyval.num) = (yyvsp[0].num) ; }
-#line 1558 "VYacc.tab.cpp"
+#line 1560 "VYacc.tab.cpp"
     break;
 
   case 44: /* number: '-' VPTT_number  */
-#line 162 "VYacc.y"
+#line 164 "VYacc.y"
                           {(yyval.num) = -(yyvsp[0].num) ;}
-#line 1564 "VYacc.tab.cpp"
+#line 1566 "VYacc.tab.cpp"
     break;
 
   case 45: /* number: '+' VPTT_number  */
-#line 163 "VYacc.y"
+#line 165 "VYacc.y"
                           {(yyval.num) = (yyvsp[0].num) ;}
-#line 1570 "VYacc.tab.cpp"
+#line 1572 "VYacc.tab.cpp"
     break;
 
   case 46: /* units: VPTT_units_symbol  */
-#line 167 "VYacc.y"
+#line 169 "VYacc.y"
                           { (yyval.uni) = (yyvsp[0].uni) ; }
-#line 1576 "VYacc.tab.cpp"
+#line 1578 "VYacc.tab.cpp"
     break;
 
   case 47: /* units: units '/' units  */
-#line 168 "VYacc.y"
+#line 170 "VYacc.y"
                           {(yyval.uni) = vpyy_unitsdiv((yyvsp[-2].uni),(yyvsp[0].uni));}
-#line 1582 "VYacc.tab.cpp"
+#line 1584 "VYacc.tab.cpp"
     break;
 
   case 48: /* units: units '*' units  */
-#line 169 "VYacc.y"
+#line 171 "VYacc.y"
                           {(yyval.uni) = vpyy_unitsmult((yyvsp[-2].uni),(yyvsp[0].uni));}
-#line 1588 "VYacc.tab.cpp"
+#line 1590 "VYacc.tab.cpp"
     break;
 
   case 49: /* units: '(' units ')'  */
-#line 170 "VYacc.y"
+#line 172 "VYacc.y"
                         { (yyval.uni) = (yyvsp[-1].uni) ; }
-#line 1594 "VYacc.tab.cpp"
+#line 1596 "VYacc.tab.cpp"
     break;
 
   case 50: /* interpmode: VPTT_interpolate  */
-#line 175 "VYacc.y"
+#line 177 "VYacc.y"
                      { (yyval.tok) = (yyvsp[0].tok) ; }
-#line 1600 "VYacc.tab.cpp"
+#line 1602 "VYacc.tab.cpp"
     break;
 
   case 51: /* interpmode: VPTT_raw  */
-#line 176 "VYacc.y"
+#line 178 "VYacc.y"
                    { (yyval.tok) = (yyvsp[0].tok) ; }
-#line 1606 "VYacc.tab.cpp"
+#line 1608 "VYacc.tab.cpp"
     break;
 
   case 52: /* interpmode: VPTT_hold_backward  */
-#line 177 "VYacc.y"
+#line 179 "VYacc.y"
                              { (yyval.tok) = (yyvsp[0].tok) ; }
-#line 1612 "VYacc.tab.cpp"
+#line 1614 "VYacc.tab.cpp"
     break;
 
   case 53: /* interpmode: VPTT_look_forward  */
-#line 178 "VYacc.y"
+#line 180 "VYacc.y"
                             { (yyval.tok) = (yyvsp[0].tok) ; }
-#line 1618 "VYacc.tab.cpp"
+#line 1620 "VYacc.tab.cpp"
     break;
 
   case 54: /* exceptlist: VPTT_except sublist  */
-#line 182 "VYacc.y"
+#line 184 "VYacc.y"
                         { (yyval.sll) = vpyy_chain_sublist(NULL,(yyvsp[0].sml)) ; }
-#line 1624 "VYacc.tab.cpp"
+#line 1626 "VYacc.tab.cpp"
     break;
 
   case 55: /* exceptlist: exceptlist ',' sublist  */
-#line 183 "VYacc.y"
+#line 185 "VYacc.y"
                                  { vpyy_chain_sublist((yyvsp[-2].sll),(yyvsp[0].sml)) ; (yyval.sll) = (yyvsp[-2].sll) ; }
-#line 1630 "VYacc.tab.cpp"
+#line 1632 "VYacc.tab.cpp"
     break;
 
   case 56: /* mapsymlist: VPTT_symbol  */
-#line 187 "VYacc.y"
+#line 189 "VYacc.y"
                     { (yyval.sml) = vpyy_symlist(NULL,(yyvsp[0].sym),0,NULL) ; }
-#line 1636 "VYacc.tab.cpp"
+#line 1638 "VYacc.tab.cpp"
     break;
 
   case 57: /* mapsymlist: '(' VPTT_symbol ':' symlist ')'  */
-#line 188 "VYacc.y"
+#line 190 "VYacc.y"
                                           { (yyval.sml) = vpyy_mapsymlist(NULL, (yyvsp[-3].sym), (yyvsp[-1].sml)); }
-#line 1642 "VYacc.tab.cpp"
+#line 1644 "VYacc.tab.cpp"
     break;
 
   case 58: /* mapsymlist: mapsymlist ',' VPTT_symbol  */
-#line 189 "VYacc.y"
+#line 191 "VYacc.y"
                                      { (yyval.sml) = vpyy_symlist((yyvsp[-2].sml),(yyvsp[0].sym),0,NULL) ;}
-#line 1648 "VYacc.tab.cpp"
+#line 1650 "VYacc.tab.cpp"
     break;
 
   case 59: /* mapsymlist: mapsymlist ',' '(' VPTT_symbol ':' symlist ')'  */
-#line 190 "VYacc.y"
+#line 192 "VYacc.y"
                                                          { (yyval.sml) = vpyy_mapsymlist((yyvsp[-6].sml), (yyvsp[-3].sym), (yyvsp[-1].sml));}
-#line 1654 "VYacc.tab.cpp"
+#line 1656 "VYacc.tab.cpp"
     break;
 
   case 60: /* maplist: %empty  */
-#line 195 "VYacc.y"
+#line 197 "VYacc.y"
     { (yyval.sml) = NULL ; }
-#line 1660 "VYacc.tab.cpp"
+#line 1662 "VYacc.tab.cpp"
     break;
 
   case 61: /* maplist: VPTT_map mapsymlist  */
-#line 196 "VYacc.y"
+#line 198 "VYacc.y"
                               { (yyval.sml) =  (yyvsp[0].sml) ; }
-#line 1666 "VYacc.tab.cpp"
+#line 1668 "VYacc.tab.cpp"
     break;
 
   case 62: /* exprlist: exp  */
-#line 201 "VYacc.y"
+#line 203 "VYacc.y"
        {(yyval.exl) = vpyy_chain_exprlist(NULL,(yyvsp[0].exn)) ;}
-#line 1672 "VYacc.tab.cpp"
+#line 1674 "VYacc.tab.cpp"
     break;
 
   case 63: /* exprlist: exprlist ',' exp  */
-#line 202 "VYacc.y"
+#line 204 "VYacc.y"
                       {(yyval.exl) = vpyy_chain_exprlist((yyvsp[-2].exl),(yyvsp[0].exn)) ; }
-#line 1678 "VYacc.tab.cpp"
+#line 1680 "VYacc.tab.cpp"
     break;
 
   case 64: /* exprlist: exprlist ';' exp  */
-#line 203 "VYacc.y"
+#line 205 "VYacc.y"
                       {(yyval.exl) = vpyy_chain_exprlist((yyvsp[-2].exl),(yyvsp[0].exn)) ; }
-#line 1684 "VYacc.tab.cpp"
+#line 1686 "VYacc.tab.cpp"
     break;
 
   case 65: /* exprlist: exprlist ';'  */
-#line 204 "VYacc.y"
+#line 206 "VYacc.y"
                   {(yyval.exl) = (yyvsp[-1].exl) ; }
-#line 1690 "VYacc.tab.cpp"
+#line 1692 "VYacc.tab.cpp"
     break;
 
   case 66: /* exp: VPTT_number  */
-#line 208 "VYacc.y"
+#line 210 "VYacc.y"
                           { (yyval.exn) = vpyy_num_expression((yyvsp[0].num)) ; }
-#line 1696 "VYacc.tab.cpp"
+#line 1698 "VYacc.tab.cpp"
     break;
 
   case 67: /* exp: VPTT_na  */
-#line 209 "VYacc.y"
+#line 211 "VYacc.y"
                                           { (yyval.exn) = vpyy_num_expression(-1E38);}
-#line 1702 "VYacc.tab.cpp"
+#line 1704 "VYacc.tab.cpp"
     break;
 
   case 68: /* exp: var  */
-#line 210 "VYacc.y"
+#line 212 "VYacc.y"
                           { (yyval.exn) = (Expression *)(yyvsp[0].var) ; }
-#line 1708 "VYacc.tab.cpp"
+#line 1710 "VYacc.tab.cpp"
     break;
 
   case 69: /* exp: VPTT_literal  */
-#line 211 "VYacc.y"
+#line 213 "VYacc.y"
                               { (yyval.exn) = vpyy_literal_expression((yyvsp[0].lit)) ; }
-#line 1714 "VYacc.tab.cpp"
+#line 1716 "VYacc.tab.cpp"
     break;
 
   case 70: /* exp: var '(' exprlist ')'  */
-#line 212 "VYacc.y"
+#line 214 "VYacc.y"
                                    { (yyval.exn) = vpyy_lookup_expression((yyvsp[-3].var),(yyvsp[-1].exl)) ; }
-#line 1720 "VYacc.tab.cpp"
+#line 1722 "VYacc.tab.cpp"
     break;
 
   case 71: /* exp: '(' exp ')'  */
-#line 213 "VYacc.y"
+#line 215 "VYacc.y"
                               { (yyval.exn) = vpyy_operator_expression('(',(yyvsp[-1].exn),NULL) ; }
-#line 1726 "VYacc.tab.cpp"
+#line 1728 "VYacc.tab.cpp"
     break;
 
   case 72: /* exp: VPTT_function '(' exprlist ')'  */
-#line 214 "VYacc.y"
+#line 216 "VYacc.y"
                                         { (yyval.exn) = vpyy_function_expression((yyvsp[-3].fnc),(yyvsp[-1].exl)) ;}
-#line 1732 "VYacc.tab.cpp"
+#line 1734 "VYacc.tab.cpp"
     break;
 
   case 73: /* exp: VPTT_function '(' exprlist ',' ')'  */
-#line 215 "VYacc.y"
+#line 217 "VYacc.y"
                                             { (yyval.exn) = vpyy_function_expression((yyvsp[-4].fnc),vpyy_chain_exprlist((yyvsp[-2].exl),vpyy_literal_expression("?"))) ;}
-#line 1738 "VYacc.tab.cpp"
+#line 1740 "VYacc.tab.cpp"
     break;
 
   case 74: /* exp: VPTT_function '(' ')'  */
-#line 216 "VYacc.y"
+#line 218 "VYacc.y"
                                { (yyval.exn) = vpyy_function_expression((yyvsp[-2].fnc),NULL) ;}
-#line 1744 "VYacc.tab.cpp"
+#line 1746 "VYacc.tab.cpp"
     break;
 
   case 75: /* exp: exp '+' exp  */
-#line 217 "VYacc.y"
+#line 219 "VYacc.y"
                           { (yyval.exn) = vpyy_operator_expression('+',(yyvsp[-2].exn),(yyvsp[0].exn)) ; }
-#line 1750 "VYacc.tab.cpp"
+#line 1752 "VYacc.tab.cpp"
     break;
 
   case 76: /* exp: exp '-' exp  */
-#line 218 "VYacc.y"
+#line 220 "VYacc.y"
                           { (yyval.exn) = vpyy_operator_expression('-',(yyvsp[-2].exn),(yyvsp[0].exn)) ; }
-#line 1756 "VYacc.tab.cpp"
+#line 1758 "VYacc.tab.cpp"
     break;
 
   case 77: /* exp: exp '*' exp  */
-#line 219 "VYacc.y"
+#line 221 "VYacc.y"
                           { (yyval.exn) = vpyy_operator_expression('*',(yyvsp[-2].exn),(yyvsp[0].exn)) ; }
-#line 1762 "VYacc.tab.cpp"
+#line 1764 "VYacc.tab.cpp"
     break;
 
   case 78: /* exp: exp '/' exp  */
-#line 220 "VYacc.y"
+#line 222 "VYacc.y"
                           { (yyval.exn) = vpyy_operator_expression('/',(yyvsp[-2].exn),(yyvsp[0].exn)) ; }
-#line 1768 "VYacc.tab.cpp"
+#line 1770 "VYacc.tab.cpp"
     break;
 
   case 79: /* exp: exp '<' exp  */
-#line 221 "VYacc.y"
+#line 223 "VYacc.y"
                           { (yyval.exn) = vpyy_operator_expression('<',(yyvsp[-2].exn),(yyvsp[0].exn)) ; }
-#line 1774 "VYacc.tab.cpp"
+#line 1776 "VYacc.tab.cpp"
     break;
 
   case 80: /* exp: exp VPTT_le exp  */
-#line 222 "VYacc.y"
+#line 224 "VYacc.y"
                           { (yyval.exn) = vpyy_operator_expression(VPTT_le,(yyvsp[-2].exn),(yyvsp[0].exn)) ; }
-#line 1780 "VYacc.tab.cpp"
+#line 1782 "VYacc.tab.cpp"
     break;
 
   case 81: /* exp: exp '>' exp  */
-#line 223 "VYacc.y"
+#line 225 "VYacc.y"
                           { (yyval.exn) = vpyy_operator_expression('>',(yyvsp[-2].exn),(yyvsp[0].exn)) ; }
-#line 1786 "VYacc.tab.cpp"
+#line 1788 "VYacc.tab.cpp"
     break;
 
   case 82: /* exp: exp VPTT_ge exp  */
-#line 224 "VYacc.y"
+#line 226 "VYacc.y"
                           { (yyval.exn) = vpyy_operator_expression(VPTT_ge,(yyvsp[-2].exn),(yyvsp[0].exn)) ; }
-#line 1792 "VYacc.tab.cpp"
+#line 1794 "VYacc.tab.cpp"
     break;
 
   case 83: /* exp: exp VPTT_ne exp  */
-#line 225 "VYacc.y"
+#line 227 "VYacc.y"
                           { (yyval.exn) = vpyy_operator_expression(VPTT_ne,(yyvsp[-2].exn),(yyvsp[0].exn)) ; }
-#line 1798 "VYacc.tab.cpp"
+#line 1800 "VYacc.tab.cpp"
     break;
 
   case 84: /* exp: exp VPTT_or exp  */
-#line 226 "VYacc.y"
+#line 228 "VYacc.y"
                           { (yyval.exn) = vpyy_operator_expression(VPTT_or,(yyvsp[-2].exn),(yyvsp[0].exn)) ; }
-#line 1804 "VYacc.tab.cpp"
+#line 1806 "VYacc.tab.cpp"
     break;
 
   case 85: /* exp: exp VPTT_and exp  */
-#line 227 "VYacc.y"
+#line 229 "VYacc.y"
                            { (yyval.exn) = vpyy_operator_expression(VPTT_and,(yyvsp[-2].exn),(yyvsp[0].exn)) ; }
-#line 1810 "VYacc.tab.cpp"
+#line 1812 "VYacc.tab.cpp"
     break;
 
   case 86: /* exp: VPTT_not exp  */
-#line 228 "VYacc.y"
+#line 230 "VYacc.y"
                                   { (yyval.exn) = vpyy_operator_expression(VPTT_not,(yyvsp[0].exn),NULL) ; }
-#line 1816 "VYacc.tab.cpp"
+#line 1818 "VYacc.tab.cpp"
     break;
 
   case 87: /* exp: exp '=' exp  */
-#line 229 "VYacc.y"
+#line 231 "VYacc.y"
                       { (yyval.exn) = vpyy_operator_expression('=',(yyvsp[-2].exn),(yyvsp[0].exn)) ; }
-#line 1822 "VYacc.tab.cpp"
+#line 1824 "VYacc.tab.cpp"
     break;
 
   case 88: /* exp: '-' exp  */
-#line 230 "VYacc.y"
+#line 232 "VYacc.y"
                           { (yyval.exn) = vpyy_operator_expression('-',NULL, (yyvsp[0].exn)) ; }
-#line 1828 "VYacc.tab.cpp"
+#line 1830 "VYacc.tab.cpp"
     break;
 
   case 89: /* exp: '+' exp  */
-#line 231 "VYacc.y"
+#line 233 "VYacc.y"
                           { (yyval.exn) = vpyy_operator_expression('+',NULL, (yyvsp[0].exn)) ; }
-#line 1834 "VYacc.tab.cpp"
+#line 1836 "VYacc.tab.cpp"
     break;
 
   case 90: /* exp: exp '^' exp  */
-#line 232 "VYacc.y"
+#line 234 "VYacc.y"
                           { (yyval.exn) = vpyy_operator_expression('^',(yyvsp[-2].exn),(yyvsp[0].exn)) ; }
-#line 1840 "VYacc.tab.cpp"
+#line 1842 "VYacc.tab.cpp"
     break;
 
   case 91: /* tablevals: tablepairs  */
-#line 236 "VYacc.y"
+#line 238 "VYacc.y"
                    { (yyval.tbl) = (yyvsp[0].tbl) ; }
-#line 1846 "VYacc.tab.cpp"
+#line 1848 "VYacc.tab.cpp"
     break;
 
   case 92: /* tablevals: '[' '(' number ',' number ')' '-' '(' number ',' number ')' ']' ',' tablepairs  */
-#line 238 "VYacc.y"
+#line 240 "VYacc.y"
         { (yyval.tbl) = vpyy_tablerange((yyvsp[0].tbl),(yyvsp[-12].num),(yyvsp[-10].num),(yyvsp[-6].num),(yyvsp[-4].num)) ; }
-#line 1852 "VYacc.tab.cpp"
+#line 1854 "VYacc.tab.cpp"
     break;
 
   case 93: /* tablevals: '[' '(' number ',' number ')' '-' '(' number ',' number ')' ',' tablepairs ']' ',' tablepairs  */
-#line 240 "VYacc.y"
+#line 242 "VYacc.y"
         { (yyval.tbl) = vpyy_tablerange((yyvsp[0].tbl),(yyvsp[-14].num),(yyvsp[-12].num),(yyvsp[-8].num),(yyvsp[-6].num)) ; }
-#line 1858 "VYacc.tab.cpp"
+#line 1860 "VYacc.tab.cpp"
     break;
 
   case 94: /* xytablevals: xytablevec  */
-#line 244 "VYacc.y"
+#line 246 "VYacc.y"
                    { (yyval.tbl) = (yyvsp[0].tbl) ; }
-#line 1864 "VYacc.tab.cpp"
+#line 1866 "VYacc.tab.cpp"
     break;
 
   case 95: /* xytablevals: '[' '(' number ',' number ')' '-' '(' number ',' number ')' ']' ',' xytablevec  */
-#line 246 "VYacc.y"
+#line 248 "VYacc.y"
         { (yyval.tbl) = vpyy_tablerange((yyvsp[0].tbl),(yyvsp[-12].num),(yyvsp[-10].num),(yyvsp[-6].num),(yyvsp[-4].num)) ; }
-#line 1870 "VYacc.tab.cpp"
+#line 1872 "VYacc.tab.cpp"
     break;
 
   case 96: /* xytablevec: number  */
-#line 250 "VYacc.y"
+#line 252 "VYacc.y"
                 { (yyval.tbl) = vpyy_tablevec(NULL,(yyvsp[0].num)) ;}
-#line 1876 "VYacc.tab.cpp"
+#line 1878 "VYacc.tab.cpp"
     break;
 
   case 97: /* xytablevec: xytablevec ',' number  */
-#line 251 "VYacc.y"
+#line 253 "VYacc.y"
                                   {(yyval.tbl) = vpyy_tablevec((yyvsp[-2].tbl),(yyvsp[0].num)) ;}
-#line 1882 "VYacc.tab.cpp"
+#line 1884 "VYacc.tab.cpp"
     break;
 
   case 98: /* tablepairs: '(' number ',' number ')'  */
-#line 256 "VYacc.y"
+#line 258 "VYacc.y"
                                   { (yyval.tbl) = vpyy_tablepair(NULL,(yyvsp[-3].num),(yyvsp[-1].num)) ;}
-#line 1888 "VYacc.tab.cpp"
+#line 1890 "VYacc.tab.cpp"
     break;
 
   case 99: /* tablepairs: tablepairs ',' '(' number ',' number ')'  */
-#line 257 "VYacc.y"
+#line 259 "VYacc.y"
                                                     {(yyval.tbl) = vpyy_tablepair((yyvsp[-6].tbl),(yyvsp[-3].num),(yyvsp[-1].num)) ;}
-#line 1894 "VYacc.tab.cpp"
+#line 1896 "VYacc.tab.cpp"
     break;
 
 
-#line 1898 "VYacc.tab.cpp"
+#line 1900 "VYacc.tab.cpp"
 
       default: break;
     }
@@ -2087,5 +2089,5 @@ yyreturnlab:
   return yyresult;
 }
 
-#line 263 "VYacc.y"
+#line 265 "VYacc.y"
 

--- a/src/Vensim/VYacc.tab.cpp
+++ b/src/Vensim/VYacc.tab.cpp
@@ -1,8 +1,8 @@
-/* A Bison parser, made by GNU Bison 3.7.4.  */
+/* A Bison parser, made by GNU Bison 3.8.2.  */
 
 /* Bison implementation for Yacc-like parsers in C
 
-   Copyright (C) 1984, 1989-1990, 2000-2015, 2018-2020 Free Software Foundation,
+   Copyright (C) 1984, 1989-1990, 2000-2015, 2018-2021 Free Software Foundation,
    Inc.
 
    This program is free software: you can redistribute it and/or modify
@@ -16,7 +16,7 @@
    GNU General Public License for more details.
 
    You should have received a copy of the GNU General Public License
-   along with this program.  If not, see <http://www.gnu.org/licenses/>.  */
+   along with this program.  If not, see <https://www.gnu.org/licenses/>.  */
 
 /* As a special exception, you may create a larger work that contains
    part or all of the Bison parser skeleton and distribute that work
@@ -46,10 +46,10 @@
    USER NAME SPACE" below.  */
 
 /* Identify Bison output, and Bison version.  */
-#define YYBISON 30704
+#define YYBISON 30802
 
 /* Bison version string.  */
-#define YYBISON_VERSION "3.7.4"
+#define YYBISON_VERSION "3.8.2"
 
 /* Skeleton name.  */
 #define YYSKELETON_NAME "yacc.c"
@@ -230,6 +230,18 @@ typedef int_least16_t yytype_int16;
 typedef short yytype_int16;
 #endif
 
+/* Work around bug in HP-UX 11.23, which defines these macros
+   incorrectly for preprocessor constants.  This workaround can likely
+   be removed in 2023, as HPE has promised support for HP-UX 11.23
+   (aka HP-UX 11i v2) only through the end of 2022; see Table 2 of
+   <https://h20195.www2.hpe.com/V2/getpdf.aspx/4AA4-7673ENW.pdf>.  */
+#ifdef __hpux
+# undef UINT_LEAST8_MAX
+# undef UINT_LEAST16_MAX
+# define UINT_LEAST8_MAX 255
+# define UINT_LEAST16_MAX 65535
+#endif
+
 #if defined __UINT_LEAST8_MAX__ && __UINT_LEAST8_MAX__ <= __INT_MAX__
 typedef __UINT_LEAST8_TYPE__ yytype_uint8;
 #elif (!defined __UINT_LEAST8_MAX__ && defined YY_STDINT_H \
@@ -327,17 +339,23 @@ typedef int yy_state_fast_t;
 
 /* Suppress unused-variable warnings by "using" E.  */
 #if ! defined lint || defined __GNUC__
-# define YYUSE(E) ((void) (E))
+# define YY_USE(E) ((void) (E))
 #else
-# define YYUSE(E) /* empty */
+# define YY_USE(E) /* empty */
 #endif
 
-#if defined __GNUC__ && ! defined __ICC && 407 <= __GNUC__ * 100 + __GNUC_MINOR__
 /* Suppress an incorrect diagnostic about yylval being uninitialized.  */
-# define YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN                            \
+#if defined __GNUC__ && ! defined __ICC && 406 <= __GNUC__ * 100 + __GNUC_MINOR__
+# if __GNUC__ * 100 + __GNUC_MINOR__ < 407
+#  define YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN                           \
+    _Pragma ("GCC diagnostic push")                                     \
+    _Pragma ("GCC diagnostic ignored \"-Wuninitialized\"")
+# else
+#  define YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN                           \
     _Pragma ("GCC diagnostic push")                                     \
     _Pragma ("GCC diagnostic ignored \"-Wuninitialized\"")              \
     _Pragma ("GCC diagnostic ignored \"-Wmaybe-uninitialized\"")
+# endif
 # define YY_IGNORE_MAYBE_UNINITIALIZED_END      \
     _Pragma ("GCC diagnostic pop")
 #else
@@ -554,7 +572,7 @@ static const yytype_int8 yytranslate[] =
 };
 
 #if YYDEBUG
-  /* YYRLINE[YYN] -- Source line where rule number YYN was defined.  */
+/* YYRLINE[YYN] -- Source line where rule number YYN was defined.  */
 static const yytype_int16 yyrline[] =
 {
        0,    86,    86,    87,    88,    89,    90,    91,    92,    93,
@@ -605,20 +623,6 @@ yysymbol_name (yysymbol_kind_t yysymbol)
 }
 #endif
 
-#ifdef YYPRINT
-/* YYTOKNUM[NUM] -- (External) token number corresponding to the
-   (internal) symbol number NUM (which must be that of a token).  */
-static const yytype_int16 yytoknum[] =
-{
-       0,   256,   257,   258,   259,   260,   261,   262,   263,   264,
-     265,   266,   267,   268,   269,   270,   271,   272,   273,   274,
-     275,   276,   277,   278,   279,   280,   281,   282,   283,   284,
-     285,   286,    37,   124,    45,    43,    61,    60,    62,    42,
-      47,    94,   126,    40,    41,    44,    58,    91,    93,    33,
-      63,    59
-};
-#endif
-
 #define YYPACT_NINF (-160)
 
 #define yypact_value_is_default(Yyn) \
@@ -629,8 +633,8 @@ static const yytype_int16 yytoknum[] =
 #define yytable_value_is_error(Yyn) \
   0
 
-  /* YYPACT[STATE-NUM] -- Index in YYTABLE of the portion describing
-     STATE-NUM.  */
+/* YYPACT[STATE-NUM] -- Index in YYTABLE of the portion describing
+   STATE-NUM.  */
 static const yytype_int16 yypact[] =
 {
       13,  -160,  -160,  -160,  -160,    -3,    10,  -160,  -160,    -6,
@@ -659,9 +663,9 @@ static const yytype_int16 yypact[] =
      273,   268
 };
 
-  /* YYDEFACT[STATE-NUM] -- Default reduction number in state STATE-NUM.
-     Performed when YYTABLE does not specify something else to do.  Zero
-     means the default is an error.  */
+/* YYDEFACT[STATE-NUM] -- Default reduction number in state STATE-NUM.
+   Performed when YYTABLE does not specify something else to do.  Zero
+   means the default is an error.  */
 static const yytype_int8 yydefact[] =
 {
        0,     3,    10,    12,     2,    25,     0,     4,     5,     0,
@@ -690,7 +694,7 @@ static const yytype_int8 yydefact[] =
        0,     0
 };
 
-  /* YYPGOTO[NTERM-NUM].  */
+/* YYPGOTO[NTERM-NUM].  */
 static const yytype_int16 yypgoto[] =
 {
     -160,  -160,  -160,  -160,  -160,  -160,  -160,   294,   -20,  -159,
@@ -698,17 +702,17 @@ static const yytype_int16 yypgoto[] =
      -18,   134,  -160,    96,   -72
 };
 
-  /* YYDEFGOTO[NTERM-NUM].  */
+/* YYDEFGOTO[NTERM-NUM].  */
 static const yytype_int8 yydefgoto[] =
 {
-      -1,     6,     7,    12,     8,     9,    10,    52,    16,    35,
+       0,     6,     7,    12,     8,     9,    10,    52,    16,    35,
       33,    41,    80,    81,    42,    27,    28,   122,    74,    56,
       57,    64,    65,    66,    67
 };
 
-  /* YYTABLE[YYPACT[STATE-NUM]] -- What to do in state STATE-NUM.  If
-     positive, shift that token.  If negative, reduce the rule whose
-     number is the opposite.  If YYTABLE_NINF, syntax error.  */
+/* YYTABLE[YYPACT[STATE-NUM]] -- What to do in state STATE-NUM.  If
+   positive, shift that token.  If negative, reduce the rule whose
+   number is the opposite.  If YYTABLE_NINF, syntax error.  */
 static const yytype_uint8 yytable[] =
 {
       63,    53,    78,    13,    68,    19,    72,    31,    82,   107,
@@ -781,8 +785,8 @@ static const yytype_int16 yycheck[] =
       44,    43,    45,   179,    45,    45,    44,   221,    45
 };
 
-  /* YYSTOS[STATE-NUM] -- The (internal number of the) accessing
-     symbol of state STATE-NUM.  */
+/* YYSTOS[STATE-NUM] -- The symbol kind of the accessing symbol of
+   state STATE-NUM.  */
 static const yytype_int8 yystos[] =
 {
        0,     7,     9,    10,    26,    29,    53,    54,    56,    57,
@@ -811,7 +815,7 @@ static const yytype_int8 yystos[] =
       48,    45
 };
 
-  /* YYR1[YYN] -- Symbol number of symbol that rule YYN derives.  */
+/* YYR1[RULE-NUM] -- Symbol kind of the left-hand side of rule RULE-NUM.  */
 static const yytype_int8 yyr1[] =
 {
        0,    52,    53,    53,    53,    53,    53,    53,    53,    53,
@@ -826,7 +830,7 @@ static const yytype_int8 yyr1[] =
       72,    73,    73,    73,    74,    74,    75,    75,    76,    76
 };
 
-  /* YYR2[YYN] -- Number of symbols on the right hand side of rule YYN.  */
+/* YYR2[RULE-NUM] -- Number of symbols on the right-hand side of rule RULE-NUM.  */
 static const yytype_int8 yyr2[] =
 {
        0,     2,     1,     1,     1,     1,     4,     4,     3,     3,
@@ -850,6 +854,7 @@ enum { YYENOMEM = -2 };
 #define YYACCEPT        goto yyacceptlab
 #define YYABORT         goto yyabortlab
 #define YYERROR         goto yyerrorlab
+#define YYNOMEM         goto yyexhaustedlab
 
 
 #define YYRECOVERING()  (!!yyerrstatus)
@@ -890,10 +895,7 @@ do {                                            \
     YYFPRINTF Args;                             \
 } while (0)
 
-/* This macro is provided for backward compatibility. */
-# ifndef YY_LOCATION_PRINT
-#  define YY_LOCATION_PRINT(File, Loc) ((void) 0)
-# endif
+
 
 
 # define YY_SYMBOL_PRINT(Title, Kind, Value, Location)                    \
@@ -917,15 +919,11 @@ yy_symbol_value_print (FILE *yyo,
                        yysymbol_kind_t yykind, YYSTYPE const * const yyvaluep)
 {
   FILE *yyoutput = yyo;
-  YYUSE (yyoutput);
+  YY_USE (yyoutput);
   if (!yyvaluep)
     return;
-# ifdef YYPRINT
-  if (yykind < YYNTOKENS)
-    YYPRINT (yyo, yytoknum[yykind], *yyvaluep);
-# endif
   YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN
-  YYUSE (yykind);
+  YY_USE (yykind);
   YY_IGNORE_MAYBE_UNINITIALIZED_END
 }
 
@@ -1039,13 +1037,13 @@ static void
 yydestruct (const char *yymsg,
             yysymbol_kind_t yykind, YYSTYPE *yyvaluep)
 {
-  YYUSE (yyvaluep);
+  YY_USE (yyvaluep);
   if (!yymsg)
     yymsg = "Deleting";
   YY_SYMBOL_PRINT (yymsg, yykind, yyvaluep, yylocationp);
 
   YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN
-  YYUSE (yykind);
+  YY_USE (yykind);
   YY_IGNORE_MAYBE_UNINITIALIZED_END
 }
 
@@ -1108,6 +1106,7 @@ yyparse (void)
   YYDPRINTF ((stderr, "Starting parse\n"));
 
   yychar = YYEMPTY; /* Cause a token to be read.  */
+
   goto yysetstate;
 
 
@@ -1133,7 +1132,7 @@ yysetstate:
 
   if (yyss + yystacksize - 1 <= yyssp)
 #if !defined yyoverflow && !defined YYSTACK_RELOCATE
-    goto yyexhaustedlab;
+    YYNOMEM;
 #else
     {
       /* Get the current used size of the three stacks, in elements.  */
@@ -1161,7 +1160,7 @@ yysetstate:
 # else /* defined YYSTACK_RELOCATE */
       /* Extend the stack our own way.  */
       if (YYMAXDEPTH <= yystacksize)
-        goto yyexhaustedlab;
+        YYNOMEM;
       yystacksize *= 2;
       if (YYMAXDEPTH < yystacksize)
         yystacksize = YYMAXDEPTH;
@@ -1172,7 +1171,7 @@ yysetstate:
           YY_CAST (union yyalloc *,
                    YYSTACK_ALLOC (YY_CAST (YYSIZE_T, YYSTACK_BYTES (yystacksize))));
         if (! yyptr)
-          goto yyexhaustedlab;
+          YYNOMEM;
         YYSTACK_RELOCATE (yyss_alloc, yyss);
         YYSTACK_RELOCATE (yyvs_alloc, yyvs);
 #  undef YYSTACK_RELOCATE
@@ -1193,6 +1192,7 @@ yysetstate:
         YYABORT;
     }
 #endif /* !defined yyoverflow && !defined YYSTACK_RELOCATE */
+
 
   if (yystate == YYFINAL)
     YYACCEPT;
@@ -1976,6 +1976,7 @@ yyerrorlab:
      label yyerrorlab therefore never appears in user code.  */
   if (0)
     YYERROR;
+  ++yynerrs;
 
   /* Do not reclaim the symbols of the rule whose action triggered
      this YYERROR.  */
@@ -2036,7 +2037,7 @@ yyerrlab1:
 `-------------------------------------*/
 yyacceptlab:
   yyresult = 0;
-  goto yyreturn;
+  goto yyreturnlab;
 
 
 /*-----------------------------------.
@@ -2044,24 +2045,22 @@ yyacceptlab:
 `-----------------------------------*/
 yyabortlab:
   yyresult = 1;
-  goto yyreturn;
+  goto yyreturnlab;
 
 
-#if !defined yyoverflow
-/*-------------------------------------------------.
-| yyexhaustedlab -- memory exhaustion comes here.  |
-`-------------------------------------------------*/
+/*-----------------------------------------------------------.
+| yyexhaustedlab -- YYNOMEM (memory exhaustion) comes here.  |
+`-----------------------------------------------------------*/
 yyexhaustedlab:
   yyerror (YY_("memory exhausted"));
   yyresult = 2;
-  goto yyreturn;
-#endif
+  goto yyreturnlab;
 
 
-/*-------------------------------------------------------.
-| yyreturn -- parsing is finished, clean up and return.  |
-`-------------------------------------------------------*/
-yyreturn:
+/*----------------------------------------------------------.
+| yyreturnlab -- parsing is finished, clean up and return.  |
+`----------------------------------------------------------*/
+yyreturnlab:
   if (yychar != YYEMPTY)
     {
       /* Make sure we have latest lookahead translation.  See comments at

--- a/src/Vensim/VYacc.tab.hpp
+++ b/src/Vensim/VYacc.tab.hpp
@@ -1,8 +1,8 @@
-/* A Bison parser, made by GNU Bison 3.7.4.  */
+/* A Bison parser, made by GNU Bison 3.8.2.  */
 
 /* Bison interface for Yacc-like parsers in C
 
-   Copyright (C) 1984, 1989-1990, 2000-2015, 2018-2020 Free Software Foundation,
+   Copyright (C) 1984, 1989-1990, 2000-2015, 2018-2021 Free Software Foundation,
    Inc.
 
    This program is free software: you can redistribute it and/or modify
@@ -16,7 +16,7 @@
    GNU General Public License for more details.
 
    You should have received a copy of the GNU General Public License
-   along with this program.  If not, see <http://www.gnu.org/licenses/>.  */
+   along with this program.  If not, see <https://www.gnu.org/licenses/>.  */
 
 /* As a special exception, you may create a larger work that contains
    part or all of the Bison parser skeleton and distribute that work
@@ -92,6 +92,8 @@ extern int vpyydebug;
 
 extern YYSTYPE vpyylval;
 
+
 int vpyyparse (void);
+
 
 #endif /* !YY_VPYY_VYACC_TAB_HPP_INCLUDED  */

--- a/src/Vensim/VYacc.y
+++ b/src/Vensim/VYacc.y
@@ -8,11 +8,13 @@ Outputs: VYacc.tab.cpp VYacc.tab.hpp
 */
 
 %{
+#include "../Log.h"
 #include "../Symbol/Parse.h"
 #include "VensimParseFunctions.h"
 extern int vpyylex (void);
 extern void vpyyerror (char const *);
 #define YYSTYPE ParseUnion
+#define YYFPRINTF XmutilLogf
 %}
      
 /* tokens returned by the tokenizer (in addition to single char tokens) */

--- a/src/Vensim/VensimParse.cpp
+++ b/src/Vensim/VensimParse.cpp
@@ -3,6 +3,8 @@
 // we include the tokenizer here because it is as easy as setting
 // up regular expressions for Flex and more easily understood
 
+#include <cstring>
+
 #include "VensimParse.h"
 #include "../Symbol/Variable.h"
 #include "../Symbol/LeftHandSide.h"
@@ -111,7 +113,7 @@ void VensimParse::ReadyFunctions()
         pSymbolNameSpace->ConfirmAllAllocations();
 	}
 	catch (...) {
-		std::cout << "Failed to initialize symbol table" << std::endl;
+		log("Failed to initialize symbol table");
 	}
 
 }
@@ -247,7 +249,7 @@ bool VensimParse::ProcessFile(const std::string &filename, const char *contents,
              else if(rval == '|') {
              }
              else if(rval == VPTT_groupstar) {
-				//printf("%s\n", mVensimLex.CurToken()->c_str());
+				//log("%s\n", mVensimLex.CurToken()->c_str());
 				// only change this if a new number
 				 std::string group_owner;
 				 char c = mVensimLex.CurToken()->at(0);
@@ -261,17 +263,16 @@ bool VensimParse::ProcessFile(const std::string &filename, const char *contents,
 				 }
              }
              else if(rval != endtok) {
-                std::cout << "Unknown terminal token " << rval << std::endl ;
+                log("Unknown terminal token %d\n", rval);
                 if(!FindNextEq(false))
                    break ;
              }
 
           }
           catch(VensimParseSyntaxError& e) {
-             std::cout << e.str << std::endl ;
-             std::cout << "Error at line " << mVensimLex.LineNumber() << " position " << mVensimLex.Position() 
-                << " in file " << sFilename << std::endl ;
-			 std::cout << ".... skipping the associated variable and looking for the next usable content.\n";
+             log("%s\n", e.str.c_str());
+             log("Error at line %d position %d in file %s\n", mVensimLex.LineNumber(), mVensimLex.Position(), sFilename.c_str());
+             log(".... skipping the associated variable and looking for the next usable content.\n");
              pSymbolNameSpace->DeleteAllUnconfirmedAllocations() ;
              noerr = false ;
              if(!FindNextEq(false)) 
@@ -296,7 +297,7 @@ bool VensimParse::ProcessFile(const std::string &filename, const char *contents,
 		   this->mVensimLex.ReadLine(buf, BUFLEN); // version line
 		   if (strncmp(buf, "V300 ", 5) && strncmp(buf, "V364 ", 5))
 		   {
-			   printf("Unrecognized version - can't read sketch info\n");
+			   log("Unrecognized version - can't read sketch info\n");
 			   noerr = false;
 			   break;
 		   }
@@ -375,7 +376,7 @@ bool VensimParse::ProcessFile(const std::string &filename, const char *contents,
 		   }
 	   }
        if (!noerr) {
-          fprintf(stderr, "warning: writing output file, but we had errors. check the result carefully.\n");
+          log("warning: writing output file, but we had errors. check the result carefully.\n");
        }
        return true ; // got something - try to put something out
     }

--- a/src/Vensim/VensimParse.h
+++ b/src/Vensim/VensimParse.h
@@ -1,7 +1,7 @@
 #ifndef _XMUTIL_VENSIM_VENSIMPARSE_H
 #define _XMUTIL_VENSIM_VENSIMPARSE_H
 #include <string>
-#include <iostream>
+
 #include "../Symbol/Parse.h"
 #include "../Symbol/Symbol.h"
 #include "../Symbol/Units.h"

--- a/src/Vensim/VensimView.cpp
+++ b/src/Vensim/VensimView.cpp
@@ -45,7 +45,7 @@ VensimVariableElement::VensimVariableElement(VensimView* view, char *curpos, cha
 		}
 	}
 	else
-		printf("Can't find - %s\n", name.c_str());
+		log("Can't find - %s\n", name.c_str());
 }
 VensimVariableElement::VensimVariableElement(VensimView* view, Variable* var, int x, int y)
 {

--- a/src/XMUtil.cpp
+++ b/src/XMUtil.cpp
@@ -1,5 +1,7 @@
 // XMUtil.cpp : Defines the entry point for the console application.
 //
+#include <cstring>
+
 #include "Vensim/VensimParse.h"
 #include "Model.h"
 #include "Unicode.h"

--- a/src/XMUtil.h
+++ b/src/XMUtil.h
@@ -3,6 +3,8 @@
 
 #include <string>
 
+#include "Log.h"
+
 #ifdef WIN32
 // XMUtil.h - globally included - generally for help with 
 // memory leak detection
@@ -73,7 +75,6 @@ extern "C" {
 // returns NULL on error or a string containing XMILE that the caller now owns
 XMUTIL_EXPORT char *convert_mdl_to_xmile(const char *mdlSource, uint32_t mdlSourceLen, const char *fileName, bool isCompact, bool isLongName, bool isAsSectors);
 }
-
 
 // utility functions
 std::string StringFromDouble(double val);

--- a/src/Xmile/XMILEGenerator.cpp
+++ b/src/Xmile/XMILEGenerator.cpp
@@ -1071,7 +1071,7 @@ void XMILEGenerator::generateView(VensimView* view, tinyxml2::XMLElement* elemen
 						tag = "flow";
 						break;
 					default:
-						fprintf(stderr, "unknown view element type %d\n", type);
+						log("unknown view element type %d\n", type);
 					}
 					if (tag.empty())
 						continue;


### PR DESCRIPTION
This makes the intention a little clearer, unifies things (now the `yacc` generated code and various functions calling `printf` and `cout <<` all direct output through the same function), and is a single function to shim/replace (I have a WebAssembly build and its useful/easy to be able to replace the `log` below with one that writes to a string).

Happy for other approaches/to incorporate feedback!

cc @bobeberlein @wasbridge 